### PR TITLE
Feat: trakt calendar display

### DIFF
--- a/plugin.video.redlight/resources/lib/caches/settings_cache.py
+++ b/plugin.video.redlight/resources/lib/caches/settings_cache.py
@@ -75,10 +75,12 @@ def _new_settings_affect_widgets(insert_list):
 		return True
 	return False
 
-def _new_setting_value(setting_id, setting_default, currentsettings, had_existing_settings):
-	if not had_existing_settings: return setting_default
+def _new_setting_value(setting_id, setting_default, currentsettings, had_existing_settings) -> str:
+	if not had_existing_settings:
+		return setting_default
 	old_setting_id = _NEW_SETTING_VALUE_MIGRATIONS.get(setting_id)
-	if not old_setting_id: return setting_default
+	if not old_setting_id:
+		return setting_default
 	return currentsettings.get(old_setting_id, setting_default)
 
 _CREDENTIAL_STRING_SETTINGS = frozenset(('tmdb_api', 'trakt.client', 'trakt.secret', 'tmdb.lists_read_token', 'omdb_api'))
@@ -655,7 +657,8 @@ def sync_settings(params={}):
 				settings_cache.set_memory_cache(setting_id, sanitized)
 	for item in d_settings:
 		setting_id = item['setting_id']
-		if setting_id in currentsettings: continue
+		if setting_id in currentsettings:
+			continue
 		setting_type = item['setting_type']
 		setting_default = item['setting_default']
 		setting_value = _new_setting_value(setting_id, setting_default, currentsettings, had_existing_settings)
@@ -664,12 +667,13 @@ def sync_settings(params={}):
 				try:
 					from apis.aiostreams_api import INSTANCE_LABELS
 					name_default = INSTANCE_LABELS.get(setting_default, item['settings_options'][setting_default])
-				except: name_default = item['settings_options'][setting_default]
+				except (ImportError, KeyError):
+					name_default = item['settings_options'][setting_default]
 				name_value = name_default
 			else:
 				name_default = item['settings_options'][setting_default]
 				name_value = item['settings_options'].get(setting_value, name_default)
-			insert_list_append(('%s_name' % setting_id, 'name', name_default, name_value))
+			insert_list_append((f'{setting_id}_name', 'name', name_default, name_value))
 		insert_list_append((setting_id, setting_type, setting_default, setting_value))
 	if insert_list:
 		settings_cache.set_many(insert_list, load_properties=load_properties)

--- a/plugin.video.redlight/resources/lib/caches/settings_cache.py
+++ b/plugin.video.redlight/resources/lib/caches/settings_cache.py
@@ -17,6 +17,10 @@ _SETTINGS_WIDGETS_MIGRATED = 'redlight.settings_widgets_migrated'
 _SETTINGS_DB_SYNCED = 'redlight.settings_db_synced'
 _SETTINGS_SYNC_FINGERPRINT = 'redlight.settings_sync_fingerprint'
 _WIDGET_REFRESH_SCHEDULED = 'redlight.widgets_refresh_scheduled'
+_NEW_SETTING_VALUE_MIGRATIONS = {
+	'trakt.calendar_display': 'single_ep_display',
+	'trakt.calendar_display_widget': 'single_ep_display_widget',
+}
 _bootstrap_lock = Lock()
 _DEFAULTS_LIST = None
 _DEFAULTS_MAP = None
@@ -70,6 +74,12 @@ def _new_settings_affect_widgets(insert_list):
 			continue
 		return True
 	return False
+
+def _new_setting_value(setting_id, setting_default, currentsettings, had_existing_settings):
+	if not had_existing_settings: return setting_default
+	old_setting_id = _NEW_SETTING_VALUE_MIGRATIONS.get(setting_id)
+	if not old_setting_id: return setting_default
+	return currentsettings.get(old_setting_id, setting_default)
 
 _CREDENTIAL_STRING_SETTINGS = frozenset(('tmdb_api', 'trakt.client', 'trakt.secret', 'tmdb.lists_read_token', 'omdb_api'))
 
@@ -648,15 +658,19 @@ def sync_settings(params={}):
 		if setting_id in currentsettings: continue
 		setting_type = item['setting_type']
 		setting_default = item['setting_default']
+		setting_value = _new_setting_value(setting_id, setting_default, currentsettings, had_existing_settings)
 		if setting_type == 'action' and 'settings_options' in item:
 			if setting_id == 'aiostreams.instance':
 				try:
 					from apis.aiostreams_api import INSTANCE_LABELS
 					name_default = INSTANCE_LABELS.get(setting_default, item['settings_options'][setting_default])
 				except: name_default = item['settings_options'][setting_default]
-			else: name_default = item['settings_options'][setting_default]
-			insert_list_append(('%s_name' % setting_id, 'name', name_default, name_default))
-		insert_list_append((setting_id, setting_type, setting_default, setting_default))
+				name_value = name_default
+			else:
+				name_default = item['settings_options'][setting_default]
+				name_value = item['settings_options'].get(setting_value, name_default)
+			insert_list_append(('%s_name' % setting_id, 'name', name_default, name_value))
+		insert_list_append((setting_id, setting_type, setting_default, setting_value))
 	if insert_list:
 		settings_cache.set_many(insert_list, load_properties=load_properties)
 		migrated = True
@@ -1032,6 +1046,8 @@ def default_settings():
 {'setting_id': 'nextep.include_unaired', 'setting_type': 'boolean', 'setting_default': 'false'},
 #======+============= Trakt Calendar
 {'setting_id': 'trakt.flatten_episodes', 'setting_type': 'boolean', 'setting_default': 'false'},
+{'setting_id': 'trakt.calendar_display', 'setting_type': 'action', 'setting_default': '0', 'settings_options': {'0': 'TITLE: SxE - EPISODE', '1': 'SxE - EPISODE', '2': 'EPISODE'}},
+{'setting_id': 'trakt.calendar_display_widget', 'setting_type': 'action', 'setting_default': '1', 'settings_options': {'0': 'TITLE: SxE - EPISODE', '1': 'SxE - EPISODE', '2': 'EPISODE'}},
 {'setting_id': 'trakt.calendar_sort_order', 'setting_type': 'action', 'setting_default': '0', 'settings_options': {'0': 'Descending', '1': 'Ascending'}},
 {'setting_id': 'trakt.calendar_previous_days', 'setting_type': 'action', 'setting_default': '7', 'min_value': '0', 'max_value': '14'},
 {'setting_id': 'trakt.calendar_future_days', 'setting_type': 'action', 'setting_default': '7', 'min_value': '0', 'max_value': '14'},

--- a/plugin.video.redlight/resources/lib/indexers/episodes.py
+++ b/plugin.video.redlight/resources/lib/indexers/episodes.py
@@ -304,8 +304,10 @@ def build_single_episode(list_type, params={}):
 	window_command = 'ActivateWindow(Videos,%s,return)' if is_external else 'Container.Update(%s)'
 	no_spoilers = settings.avoid_episode_spoilers()
 	watched_indicators = settings.watched_indicators()
-	if list_type == 'episode.trakt': display_format = settings.calendar_display_format(is_external)
-	else: display_format = settings.single_ep_display_format(is_external)
+	if list_type == 'episode.trakt':
+		display_format = settings.calendar_display_format(is_external)
+	else:
+		display_format = settings.single_ep_display_format(is_external)
 	current_date, current_time, adjust_hours = get_datetime(), get_current_timestamp(), settings.date_offset()
 	unwatched_info = settings.single_ep_unwatched_episodes()
 	hide_watched = is_external and settings.widget_hide_watched() and list_type != 'episode.recently_watched'

--- a/plugin.video.redlight/resources/lib/indexers/episodes.py
+++ b/plugin.video.redlight/resources/lib/indexers/episodes.py
@@ -303,7 +303,9 @@ def build_single_episode(list_type, params={}):
 	item_list_append = item_list.append
 	window_command = 'ActivateWindow(Videos,%s,return)' if is_external else 'Container.Update(%s)'
 	no_spoilers = settings.avoid_episode_spoilers()
-	watched_indicators, display_format = settings.watched_indicators(), settings.single_ep_display_format(is_external)
+	watched_indicators = settings.watched_indicators()
+	if list_type == 'episode.trakt': display_format = settings.calendar_display_format(is_external)
+	else: display_format = settings.single_ep_display_format(is_external)
 	current_date, current_time, adjust_hours = get_datetime(), get_current_timestamp(), settings.date_offset()
 	unwatched_info = settings.single_ep_unwatched_episodes()
 	hide_watched = is_external and settings.widget_hide_watched() and list_type != 'episode.recently_watched'

--- a/plugin.video.redlight/resources/lib/modules/settings.py
+++ b/plugin.video.redlight/resources/lib/modules/settings.py
@@ -485,6 +485,11 @@ def single_ep_display_format(is_external):
 	else: setting, default = 'redlight.single_ep_display', ''
 	return int(get_setting(setting, default))
 
+def calendar_display_format(is_external):
+	if is_external: setting, default = 'redlight.trakt.calendar_display_widget', '1'
+	else: setting, default = 'redlight.trakt.calendar_display', '0'
+	return int(get_setting(setting, default))
+
 def easynews_active():
 	if get_setting('redlight.provider.easynews', 'false') == 'true': easynews_status = easynews_authorized()
 	else: easynews_status = False

--- a/plugin.video.redlight/resources/lib/modules/settings.py
+++ b/plugin.video.redlight/resources/lib/modules/settings.py
@@ -486,8 +486,10 @@ def single_ep_display_format(is_external):
 	return int(get_setting(setting, default))
 
 def calendar_display_format(is_external):
-	if is_external: setting, default = 'redlight.trakt.calendar_display_widget', '1'
-	else: setting, default = 'redlight.trakt.calendar_display', '0'
+	if is_external:
+		setting, default = 'redlight.trakt.calendar_display_widget', '1'
+	else:
+		setting, default = 'redlight.trakt.calendar_display', '0'
 	return int(get_setting(setting, default))
 
 def easynews_active():

--- a/plugin.video.redlight/resources/skins/Default/1080i/settings_manager.xml
+++ b/plugin.video.redlight/resources/skins/Default/1080i/settings_manager.xml
@@ -1535,6 +1535,22 @@
                       </item>
                       <item>
                           <visible>Container(2000).HasFocus(40)</visible>
+                          <property name="setting_label">Calendar Display Format - Within Addon</property>
+                          <property name="setting_type">action</property>
+                          <property name="setting_value">$INFO[Window(10000).Property(redlight.trakt.calendar_display_name)]</property>
+                          <property name="setting_description">Choose the display format Red Light uses when naming episodes within the Trakt Calendar in the addon</property>
+                          <onclick>RunPlugin(plugin://plugin.video.redlight/?mode=settings_manager.set_from_list&amp;setting_id=trakt.calendar_display)</onclick>
+                      </item>
+                      <item>
+                          <visible>Container(2000).HasFocus(40)</visible>
+                          <property name="setting_label">Calendar Display Format - Widgets</property>
+                          <property name="setting_type">action</property>
+                          <property name="setting_value">$INFO[Window(10000).Property(redlight.trakt.calendar_display_widget_name)]</property>
+                          <property name="setting_description">Choose the display format Red Light uses when naming episodes in the Trakt Calendar for widgets</property>
+                          <onclick>RunPlugin(plugin://plugin.video.redlight/?mode=settings_manager.set_from_list&amp;setting_id=trakt.calendar_display_widget)</onclick>
+                      </item>
+                      <item>
+                          <visible>Container(2000).HasFocus(40)</visible>
                           <property name="setting_label">Sort Order</property>
                           <property name="setting_type">action</property>
                           <property name="setting_value">$INFO[Window(10000).Property(redlight.trakt.calendar_sort_order_name)]</property>

--- a/tests/test_settings_cache_calendar_migration.py
+++ b/tests/test_settings_cache_calendar_migration.py
@@ -85,20 +85,45 @@ class FakeSettingsCache:
 class CalendarDisplayMigrationTests(unittest.TestCase):
 	@classmethod
 	def setUpClass(cls):
+		cls._original_sys_modules = {}
+		for key in ('modules', 'modules.kodi_utils', 'modules.settings', 'caches', 'caches.base_cache'):
+			if key in sys.modules:
+				cls._original_sys_modules[key] = sys.modules[key]
 		cls.module = _load_settings_cache_module()
+
+	@classmethod
+	def tearDownClass(cls):
+		for key in ('modules', 'modules.kodi_utils', 'modules.settings', 'caches', 'caches.base_cache'):
+			if key in cls._original_sys_modules:
+				sys.modules[key] = cls._original_sys_modules[key]
+			else:
+				sys.modules.pop(key, None)
 
 	def setUp(self):
 		self.module._test_properties.clear()
-		self.module.default_settings = lambda: [
-			{'setting_id': 'single_ep_display', 'setting_type': 'action', 'setting_default': '0',
-			 'settings_options': {'0': 'TITLE: SxE - EPISODE', '1': 'SxE - EPISODE', '2': 'EPISODE'}},
-			{'setting_id': 'single_ep_display_widget', 'setting_type': 'action', 'setting_default': '1',
-			 'settings_options': {'0': 'TITLE: SxE - EPISODE', '1': 'SxE - EPISODE', '2': 'EPISODE'}},
-			{'setting_id': 'trakt.calendar_display', 'setting_type': 'action', 'setting_default': '0',
-			 'settings_options': {'0': 'TITLE: SxE - EPISODE', '1': 'SxE - EPISODE', '2': 'EPISODE'}},
-			{'setting_id': 'trakt.calendar_display_widget', 'setting_type': 'action', 'setting_default': '1',
-			 'settings_options': {'0': 'TITLE: SxE - EPISODE', '1': 'SxE - EPISODE', '2': 'EPISODE'}},
-		]
+		production_defaults = self.module.default_settings()
+		calendar_settings = {
+			s['setting_id']: s for s in production_defaults
+			if s['setting_id'] in ('single_ep_display', 'single_ep_display_widget', 'trakt.calendar_display', 'trakt.calendar_display_widget')
+		}
+		expected_calendar_metadata = {
+			'single_ep_display': {'setting_type': 'action', 'setting_default': '0',
+								  'settings_options': {'0': 'TITLE: SxE - EPISODE', '1': 'SxE - EPISODE', '2': 'EPISODE'}},
+			'single_ep_display_widget': {'setting_type': 'action', 'setting_default': '1',
+										 'settings_options': {'0': 'TITLE: SxE - EPISODE', '1': 'SxE - EPISODE', '2': 'EPISODE'}},
+			'trakt.calendar_display': {'setting_type': 'action', 'setting_default': '0',
+									   'settings_options': {'0': 'TITLE: SxE - EPISODE', '1': 'SxE - EPISODE', '2': 'EPISODE'}},
+			'trakt.calendar_display_widget': {'setting_type': 'action', 'setting_default': '1',
+											  'settings_options': {'0': 'TITLE: SxE - EPISODE', '1': 'SxE - EPISODE', '2': 'EPISODE'}},
+		}
+		for setting_id, expected_meta in expected_calendar_metadata.items():
+			actual = calendar_settings.get(setting_id, {})
+			self.assertEqual(expected_meta['setting_type'], actual.get('setting_type'),
+							 f"Production default for {setting_id} setting_type changed")
+			self.assertEqual(expected_meta['setting_default'], actual.get('setting_default'),
+							 f"Production default for {setting_id} setting_default changed")
+			self.assertEqual(expected_meta['settings_options'], actual.get('settings_options'),
+							 f"Production default for {setting_id} settings_options changed")
 
 	def _sync(self, initial):
 		cache = FakeSettingsCache(initial)

--- a/tests/test_settings_cache_calendar_migration.py
+++ b/tests/test_settings_cache_calendar_migration.py
@@ -1,0 +1,144 @@
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SETTINGS_CACHE_PATH = ROOT / 'plugin.video.redlight' / 'resources' / 'lib' / 'caches' / 'settings_cache.py'
+
+
+def _load_settings_cache_module():
+	properties = {}
+	kodi_utils = types.ModuleType('modules.kodi_utils')
+	kodi_utils.addon_fanart = lambda: ''
+	kodi_utils.addon_info = lambda key: 'test-version' if key == 'version' else ''
+	kodi_utils.clear_property = lambda key: properties.pop(key, None)
+	kodi_utils.get_property = lambda key: properties.get(key, '')
+	kodi_utils.is_android = lambda: False
+	kodi_utils.logger = lambda *args, **kwargs: None
+	kodi_utils.notification = lambda *args, **kwargs: None
+	kodi_utils.path_exists = lambda path: False
+	kodi_utils.schedule_widget_refresh = lambda **kwargs: None
+	kodi_utils.set_property = lambda key, value: properties.__setitem__(key, value)
+	kodi_utils.translate_path = lambda path: path
+
+	modules = types.ModuleType('modules')
+	modules.__path__ = []
+	modules.kodi_utils = kodi_utils
+	settings = types.ModuleType('modules.settings')
+	settings.migrate_cm_manager_order_for_upgrade = lambda: False
+	settings.migrate_external_scraper_context_menu_for_upgrade = lambda had_existing: False
+	settings.migrate_external_scraper_run_mode_for_upgrade = lambda had_existing: False
+	settings.migrate_external_scraper_slots_for_upgrade = lambda had_existing: False
+	settings.migrate_mdblist_context_menu_for_upgrade = lambda had_existing: False
+	settings.migrate_simkl_context_menu_for_upgrade = lambda had_existing: False
+
+	caches = types.ModuleType('caches')
+	caches.__path__ = []
+	base_cache = types.ModuleType('caches.base_cache')
+	base_cache.connect_database = lambda name: None
+
+	sys.modules['modules'] = modules
+	sys.modules['modules.kodi_utils'] = kodi_utils
+	sys.modules['modules.settings'] = settings
+	sys.modules['caches'] = caches
+	sys.modules['caches.base_cache'] = base_cache
+
+	spec = importlib.util.spec_from_file_location('settings_cache_under_test', SETTINGS_CACHE_PATH)
+	module = importlib.util.module_from_spec(spec)
+	spec.loader.exec_module(module)
+	module._test_properties = properties
+	return module
+
+
+class FakeSettingsCache:
+	def __init__(self, initial=None):
+		self.data = dict(initial or {})
+		self.rows = {}
+
+	def clean_database(self):
+		return True
+
+	def clear_db_cache(self):
+		pass
+
+	def get_all(self):
+		return dict(self.data)
+
+	def remove_setting(self, setting_id):
+		self.data.pop(setting_id, None)
+
+	def set_many(self, settings_list, load_properties=True):
+		for row in settings_list:
+			self.rows[row[0]] = row
+			self.data[row[0]] = row[3]
+
+	def set_memory_cache(self, setting_id, value):
+		pass
+
+	def write_db(self, setting_id, setting_value, setting_info=None):
+		self.data[setting_id] = setting_value
+
+
+class CalendarDisplayMigrationTests(unittest.TestCase):
+	@classmethod
+	def setUpClass(cls):
+		cls.module = _load_settings_cache_module()
+
+	def setUp(self):
+		self.module._test_properties.clear()
+		self.module.default_settings = lambda: [
+			{'setting_id': 'single_ep_display', 'setting_type': 'action', 'setting_default': '0',
+			 'settings_options': {'0': 'TITLE: SxE - EPISODE', '1': 'SxE - EPISODE', '2': 'EPISODE'}},
+			{'setting_id': 'single_ep_display_widget', 'setting_type': 'action', 'setting_default': '1',
+			 'settings_options': {'0': 'TITLE: SxE - EPISODE', '1': 'SxE - EPISODE', '2': 'EPISODE'}},
+			{'setting_id': 'trakt.calendar_display', 'setting_type': 'action', 'setting_default': '0',
+			 'settings_options': {'0': 'TITLE: SxE - EPISODE', '1': 'SxE - EPISODE', '2': 'EPISODE'}},
+			{'setting_id': 'trakt.calendar_display_widget', 'setting_type': 'action', 'setting_default': '1',
+			 'settings_options': {'0': 'TITLE: SxE - EPISODE', '1': 'SxE - EPISODE', '2': 'EPISODE'}},
+		]
+
+	def _sync(self, initial):
+		cache = FakeSettingsCache(initial)
+		self.module.settings_cache = cache
+		result = self.module.sync_settings({'silent': 'true', 'load_properties': 'false', 'force': 'true'})
+		self.assertEqual('synced', result)
+		return cache
+
+	def test_upgrade_copies_existing_single_episode_preferences(self):
+		cache = self._sync({
+			'single_ep_display': '2',
+			'single_ep_display_widget': '0',
+		})
+
+		self.assertEqual('2', cache.data['trakt.calendar_display'])
+		self.assertEqual('0', cache.data['trakt.calendar_display_widget'])
+		self.assertEqual('EPISODE', cache.data['trakt.calendar_display_name'])
+		self.assertEqual('TITLE: SxE - EPISODE', cache.data['trakt.calendar_display_widget_name'])
+		self.assertEqual('0', cache.rows['trakt.calendar_display'][2])
+		self.assertEqual('1', cache.rows['trakt.calendar_display_widget'][2])
+
+	def test_fresh_install_uses_new_setting_defaults(self):
+		cache = self._sync({})
+
+		self.assertEqual('0', cache.data['trakt.calendar_display'])
+		self.assertEqual('1', cache.data['trakt.calendar_display_widget'])
+		self.assertEqual('TITLE: SxE - EPISODE', cache.data['trakt.calendar_display_name'])
+		self.assertEqual('SxE - EPISODE', cache.data['trakt.calendar_display_widget_name'])
+
+	def test_existing_calendar_preferences_are_not_overwritten(self):
+		cache = self._sync({
+			'single_ep_display': '2',
+			'single_ep_display_widget': '0',
+			'trakt.calendar_display': '1',
+			'trakt.calendar_display_widget': '2',
+		})
+
+		self.assertEqual('1', cache.data['trakt.calendar_display'])
+		self.assertEqual('2', cache.data['trakt.calendar_display_widget'])
+
+
+if __name__ == '__main__':
+	unittest.main()


### PR DESCRIPTION
### Purpose
 
#101 

Add dedicated display-format controls for Trakt Calendar episode titles without changing existing users' effective formatting preference during upgrade.

### Summary of Changes

- Added separate within-addon and widget display-format settings for Trakt Calendar entries.
- Routed Trakt Calendar episode title construction through the new settings.
- Migrated newly created calendar settings from the corresponding legacy single-episode values on upgrades.
- Kept the new `0`/`1` defaults for fresh installations.
- Added regression coverage for upgrades, fresh installs, and already-existing calendar preferences.


### Files and Components Affected

- `plugin.video.redlight/resources/lib/caches/settings_cache.py`
- `plugin.video.redlight/resources/lib/modules/settings.py`
- `plugin.video.redlight/resources/lib/indexers/episodes.py`
- `plugin.video.redlight/resources/skins/Default/1080i/settings_manager.xml`
- `tests/test_settings_cache_calendar_migration.py`
