### PR TITLE
feat: skip Extras/Movie Set open action for in-progress movies

### DIFF
--- a/plugin.video.redlight/resources/lib/caches/settings_cache.py
+++ b/plugin.video.redlight/resources/lib/caches/settings_cache.py
@@ -958,6 +958,7 @@ def default_settings():
 #==================== Special Open Actions
 {'setting_id': 'media_open_action_movie', 'setting_type': 'action', 'setting_default': '0', 'settings_options': {'0': 'None', '1': 'Open Extras', '2': 'Open Movie Set', '3': 'Both'}},
 {'setting_id': 'media_open_action_tvshow', 'setting_type': 'action', 'setting_default': '0', 'settings_options': {'0': 'None', '1': 'Open Extras'}},
+{'setting_id': 'media_open_action_skip_inprogress_movie', 'setting_type': 'boolean', 'setting_default': 'false'},
 #==================== AI Generated Similar Titles
 {'setting_id': 'ai_model.order', 'setting_type': 'string', 'setting_default': 'gemini-2.5-flash-lite,llama-3.3-70b-versatile,gemma-3-27b-it,llama-3.1-8b-instant'},
 {'setting_id': 'ai_model.limit', 'setting_type': 'action', 'setting_default': '15', 'min_value': '1', 'max_value': '25'},

--- a/plugin.video.redlight/resources/lib/indexers/movies.py
+++ b/plugin.video.redlight/resources/lib/indexers/movies.py
@@ -235,16 +235,24 @@ class Movies:
 			tmdb_manager_params = self.build_url({'mode': 'tmdblists_manager_choice', 'media_type': 'movie', 'tmdb_id': tmdb_id, 'icon': poster})
 			favorites_manager_params = self.build_url({'mode': 'favorites_manager_choice', 'media_type': 'movie', 'tmdb_id': tmdb_id, 'title': title})
 			belongs_to_movieset = 'true' if all([movieset_id, movieset_name]) else 'false'
-			movieset_active = self.open_movieset and belongs_to_movieset == 'true'
-			if self.open_extras or movieset_active: cm_append(['extras', ('[B]Play[/B]', 'RunPlugin(%s)' % play_params)])
-			if not self.open_extras or movieset_active: cm_append(['extras', ('[B]Extras[/B]', 'RunPlugin(%s)' % extras_params)])
-			if movieset_active: url_params = self.build_url({'mode': 'open_movieset_choice', 'key_id': movieset_id, 'name': movieset_name, 'is_external': self.is_external})
-			elif self.open_extras: url_params = extras_params
-			else: url_params = play_params
+			skip_special = self.skip_inprogress and progress
+			item_open_extras = self.open_extras and not skip_special
+			item_open_movieset = self.open_movieset and not skip_special
+			movieset_active = item_open_movieset and belongs_to_movieset == 'true'
+			if item_open_extras or movieset_active:
+				cm_append(['extras', ('[B]Play[/B]', 'RunPlugin(%s)' % play_params)])
+			if not item_open_extras or movieset_active:
+				cm_append(['extras', ('[B]Extras[/B]', 'RunPlugin(%s)' % extras_params)])
+			if movieset_active:
+				url_params = self.build_url({'mode': 'open_movieset_choice', 'key_id': movieset_id, 'name': movieset_name, 'is_external': self.is_external})
+			elif item_open_extras:
+				url_params = extras_params
+			else:
+				url_params = play_params
 			cm_append(['options', ('[B]Options[/B]', 'RunPlugin(%s)' % options_params)])
 			cm_append(['playback_options', ('[B]Play Options[/B]', 'RunPlugin(%s)' % playback_options_params)])
 			settings.append_external_scraper_settings_cm(cm_append, self.build_url)
-			if belongs_to_movieset == 'true' and not self.movieset_list_active and not self.open_movieset:
+			if belongs_to_movieset == 'true' and not self.movieset_list_active and not item_open_movieset:
 				browse_movie_set_params = self.build_url({'mode': 'build_movie_list', 'action': 'tmdb_movies_sets', 'key_id': movieset_id,
 										'name': movieset_name, 'is_external': self.is_external})
 				cm_append(['browse_movie_set', ('[B]Browse Movie Set[/B]', self.window_command % browse_movie_set_params)])
@@ -328,6 +336,7 @@ class Movies:
 		open_action = settings.media_open_action('movie')
 		self.open_movieset = open_action in (2, 3) and not self.movieset_list_active
 		self.open_extras = open_action in (1, 3)
+		self.skip_inprogress = settings.media_open_action_skip_inprogress_movie()
 		if self.custom_order:
 			threads = TaskPool().tasks(self.build_movie_content, self.list, min(len(self.list), settings.max_threads()))
 			[i.join() for i in threads]

--- a/plugin.video.redlight/resources/lib/modules/settings.py
+++ b/plugin.video.redlight/resources/lib/modules/settings.py
@@ -950,6 +950,9 @@ def date_offset():
 def media_open_action(media_type):
 	return int(get_setting('redlight.media_open_action_%s' % media_type, '0'))
 
+def media_open_action_skip_inprogress_movie():
+	return get_setting('redlight.media_open_action_skip_inprogress_movie', 'false') == 'true'
+
 def _resolve_watched_provider():
 	ind = int(get_setting('redlight.watched_indicators', '0'))
 	if ind == 1 and not trakt_user_active(): return 0

--- a/plugin.video.redlight/resources/skins/Default/1080i/settings_manager.xml
+++ b/plugin.video.redlight/resources/skins/Default/1080i/settings_manager.xml
@@ -857,6 +857,14 @@
                       </item>
                       <item>
                           <visible>Container(2000).HasFocus(20)</visible>
+                          <property name="setting_label">Skip on In-Progress Movies</property>
+                          <property name="setting_type">boolean</property>
+                          <property name="setting_value">$INFO[Window(10000).Property(redlight.media_open_action_skip_inprogress_movie)]</property>
+                          <property name="setting_description">Choose this and the Movies Open Action (Extras / Movie Set) is skipped for in-progress movies, resuming playback directly. Extras and Movie Set remain available in the context menu</property>
+                          <onclick>RunPlugin(plugin://plugin.video.redlight/?mode=settings_manager.set_boolean&amp;setting_id=media_open_action_skip_inprogress_movie)</onclick>
+                      </item>
+                      <item>
+                          <visible>Container(2000).HasFocus(20)</visible>
                           <property name="setting_label">TV Shows</property>
                           <property name="setting_type">action</property>
                           <property name="setting_value">$INFO[Window(10000).Property(redlight.media_open_action_tvshow_name)]</property>

--- a/plugin.video.redlight/resources/text/tips/112. Special Open Actions.txt
+++ b/plugin.video.redlight/resources/text/tips/112. Special Open Actions.txt
@@ -1,2 +1,4 @@
 
 In Settings-->Features-->Special Open Actions there is a setting to allow Red Light to open the "Extras" and/or "Movie Set" windows when selecting a Movie and the "Extras" window when selecting a TV Show.
+
+The "Skip on In-Progress Movies" toggle makes Red Light skip that Open Action for in-progress movies, resuming playback directly instead. The "Extras" and "Movie Set" remain available in the context menu.


### PR DESCRIPTION
## What

Fixes #77 
Adds a **Skip on In-Progress Movies** toggle under `Settings → Features → Special Open Actions`. When enabled, selecting an in-progress movie resumes playback directly instead of opening the Extras/Movie Set window.

## Behaviour
- Toggle **off** (default): no change to current behaviour.
- Toggle **on** + movie in progress: click resumes playback. Extras stays in the context menu; Movie Set reachable via the **Browse Movie Set** context item.
- Non-in-progress movies keep their normal open action.
- Covers both Extras and Movie Set.

## Changes
- `settings_cache.py`: new boolean `media_open_action_skip_inprogress_movie` (default `false`).
- `settings.py`: reader helper.
- `settings_manager.xml`: toggle UI item.
- `indexers/movies.py`: per-item override skips the open action when the movie is in progress.
- Tip `112. Special Open Actions`: documented.

Previously reviewed and merged in my fork: JMAN730/TheRedWizard#31

🤖 Generated with [Claude Code](https://claude.com/claude-code)