### PR TITLE
fix: audio language tags as Sort To Top options

### DIFF
--- a/plugin.video.redlight/resources/lib/modules/source_utils.py
+++ b/plugin.video.redlight/resources/lib/modules/source_utils.py
@@ -34,6 +34,19 @@ def audio_filter_choices():
 ('DTS', 'DTS'), ('DTS-HD MASTER AUDIO', 'DTS-HD MA'), ('DTS-X', 'DTS-X'), ('DTS-HD', 'DTS-HD'), ('AAC', 'AAC'), ('OPUS', 'OPUS'), ('MP3', 'MP3'),
 ('8CH AUDIO', '8CH'), ('7CH AUDIO', '7CH'), ('6CH AUDIO', '6CH'), ('2CH AUDIO', '2CH'))
 
+def audio_lang_choices():
+	return (
+('ENGLISH AUDIO', 'ENG', ('.eng.', '.english.')),
+('SPANISH AUDIO', 'SPA', ('.spa.', '.spanish.', '.esp.', '.castellano.', '.latino.')),
+('FRENCH AUDIO', 'FRE', ('.fre.', '.french.', '.fra.', '.vff.', '.vfq.', '.truefrench.')),
+('GERMAN AUDIO', 'GER', ('.ger.', '.german.', '.deu.')),
+('ITALIAN AUDIO', 'ITA', ('.ita.', '.italian.')),
+('PORTUGUESE AUDIO', 'POR', ('.por.', '.portuguese.', '.dublado.')),
+('HINDI AUDIO', 'HIN', ('.hin.', '.hindi.')),
+('JAPANESE AUDIO', 'JPN', ('.jpn.', '.japanese.', '.jap.')),
+('KOREAN AUDIO', 'KOR', ('.kor.', '.korean.')),
+('RUSSIAN AUDIO', 'RUS', ('.rus.', '.russian.')))
+
 def source_filters():
 	return (
 ('PACK', 'PACK'), ('DOLBY VISION', '[B]D/VISION[/B]'), ('HIGH DYNAMIC RANGE (HDR)', '[B]HDR[/B]'), ('IMAX', 'IMAX'), ('HYBRID', '[B]HYBRID[/B]'), ('AV1', '[B]AV1[/B]'),
@@ -41,7 +54,7 @@ def source_filters():
 ('DOLBY ATMOS', 'ATMOS'), ('DOLBY TRUEHD', 'TRUEHD'), ('DOLBY DIGITAL EX', 'DD-EX'), ('DOLBY DIGITAL PLUS', 'DD+'), ('DOLBY DIGITAL', 'DD'),
 ('DTS-HD MASTER AUDIO', 'DTS-HD MA'), ('DTS-X', 'DTS-X'), ('DTS-HD', 'DTS-HD'), ('DTS', 'DTS'), ('AAC', 'AAC'), ('OPUS', 'OPUS'), ('MP3', 'MP3'), ('8CH AUDIO', '8CH'),
 ('7CH AUDIO', '7CH'), ('6CH AUDIO', '6CH'), ('2CH AUDIO', '2CH'), ('DVD SOURCE', 'DVD'), ('WEB SOURCE', 'WEB'), ('MULTIPLE LANGUAGES', 'MULTI-LANG'),
-('SUBTITLES', 'SUBS'))
+('SUBTITLES', 'SUBS')) + tuple((name, tag) for name, tag, _ in audio_lang_choices())
 
 def include_exclude_filters():
 	return {'hevc': 'HEVC', '3d': '3D', 'hdr': 'HDR', 'dv': 'D/VISION', 'av1': 'AV1', 'enhanced_upscaled': 'AI ENHANCED/UPSCALED', 'hybrid': 'HYBRID'}
@@ -407,6 +420,12 @@ def get_info(title):
 		info_append('AVI')
 	elif any(i in title for i in ('.mkv', 'matroska')):
 		info_append('MKV')
+	# audio language tags: subtitle-adjacent codes (eng.subs, subs.eng) are subtitles, not audio
+	lang_title = re.sub(r'\.(subs?|subbed)\.([a-z]{2,12})\.', '.', title)
+	lang_title = re.sub(r'\.([a-z]{2,12})\.(subs?|subbed)\.', '.', lang_title)
+	for _, lang_tag, lang_patterns in audio_lang_choices():
+		if any(i in lang_title for i in lang_patterns):
+			info_append(lang_tag)
 	if any(i in title for i in ('hindi.eng', 'ara.eng', 'ces.eng', 'chi.eng', 'cze.eng', 'dan.eng', 'dut.eng', 'ell.eng', 'esl.eng', 'esp.eng', 'fin.eng', 'fra.eng',
 		'fre.eng', 'frn.eng', 'gai.eng', 'ger.eng', 'gle.eng', 'gre.eng', 'gtm.eng', 'heb.eng', 'hin.eng', 'hun.eng', 'ind.eng', 'iri.eng', 'ita.eng', 'jap.eng',
 		'jpn.eng', 'kor.eng', 'lat.eng', 'lebb.eng', 'lit.eng', 'nor.eng', 'pol.eng', 'por.eng', 'rus.eng', 'som.eng', 'spa.eng', 'sve.eng', 'swe.eng', 'tha.eng',

--- a/plugin.video.redlight/resources/lib/modules/sources.py
+++ b/plugin.video.redlight/resources/lib/modules/sources.py
@@ -10,7 +10,7 @@ from caches.settings_cache import get_setting
 from scrapers import external, folders
 from modules import debrid, kodi_utils, settings, metadata, watched_status
 from modules.player import RedLightPlayer
-from modules.source_utils import get_cache_expiry, make_alias_dict, include_exclude_filters, get_file_info, release_info_format
+from modules.source_utils import get_cache_expiry, make_alias_dict, include_exclude_filters, get_file_info, release_info_format, audio_lang_choices
 from modules.utils import clean_file_name, string_to_float, safe_string, remove_accents, get_datetime, append_module_to_syspath, manual_function_import
 # logger = kodi_utils.logger
 
@@ -718,6 +718,7 @@ class Sources():
 		key = (tag or '').lower().replace('[b]', '').replace('[/b]', '').strip()
 		if key in self.filter_keys: return self.filter_keys[key]
 		aliases = {'d/vision': 'D/VISION', 'dolby vision': 'D/VISION', 'hdr': 'HDR', 'high dynamic range (hdr)': 'HDR', 'dolby atmos': 'ATMOS', 'atmos': 'ATMOS', 'hevc (x265)': 'HEVC', 'hevc': 'HEVC'}
+		aliases.update({name.lower(): lang_tag for name, lang_tag, _ in audio_lang_choices()})
 		return aliases.get(key, tag)
 
 	def _parse_extra_info_tags(self, extra_info):

--- a/tests/test_source_utils_audio_lang.py
+++ b/tests/test_source_utils_audio_lang.py
@@ -1,0 +1,136 @@
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE_UTILS_PATH = ROOT / 'plugin.video.redlight' / 'resources' / 'lib' / 'modules' / 'source_utils.py'
+
+
+def _load_source_utils_module():
+	caches = types.ModuleType('caches')
+	caches.__path__ = []
+
+	settings_cache = types.ModuleType('caches.settings_cache')
+	settings_cache.get_setting = lambda setting_id, fallback=None: fallback
+
+	modules = types.ModuleType('modules')
+	modules.__path__ = []
+
+	metadata = types.ModuleType('modules.metadata')
+	metadata.episodes_meta = lambda *args, **kwargs: []
+
+	settings = types.ModuleType('modules.settings')
+	settings.date_offset = lambda: 0
+
+	kodi_utils = types.ModuleType('modules.kodi_utils')
+	kodi_utils.supported_media = lambda: ''
+	kodi_utils.get_property = lambda key: ''
+	kodi_utils.set_property = lambda key, value: None
+	kodi_utils.notification = lambda *args, **kwargs: None
+
+	utils = types.ModuleType('modules.utils')
+	utils.adjust_premiered_date = lambda *args, **kwargs: (None, None)
+	utils.get_datetime = lambda: None
+	utils.jsondate_to_datetime = lambda *args, **kwargs: None
+	utils.subtract_dates = lambda *args, **kwargs: 0
+	utils.chunks = lambda lst, n: []
+
+	requests_stub = sys.modules.get('requests') or types.ModuleType('requests')
+
+	sys.modules['caches'] = caches
+	sys.modules['caches.settings_cache'] = settings_cache
+	sys.modules['modules'] = modules
+	sys.modules['modules.metadata'] = metadata
+	sys.modules['modules.settings'] = settings
+	sys.modules['modules.kodi_utils'] = kodi_utils
+	sys.modules['modules.utils'] = utils
+	sys.modules['requests'] = requests_stub
+
+	spec = importlib.util.spec_from_file_location('source_utils_under_test', SOURCE_UTILS_PATH)
+	module = importlib.util.module_from_spec(spec)
+	spec.loader.exec_module(module)
+	return module
+
+
+source_utils = _load_source_utils_module()
+
+EXPECTED_LANGS = (
+	('ENGLISH AUDIO', 'ENG'), ('SPANISH AUDIO', 'SPA'), ('FRENCH AUDIO', 'FRE'), ('GERMAN AUDIO', 'GER'),
+	('ITALIAN AUDIO', 'ITA'), ('PORTUGUESE AUDIO', 'POR'), ('HINDI AUDIO', 'HIN'), ('JAPANESE AUDIO', 'JPN'),
+	('KOREAN AUDIO', 'KOR'), ('RUSSIAN AUDIO', 'RUS'))
+
+
+def _info_tags(release_title):
+	title = source_utils.release_info_format(release_title)
+	info = source_utils.get_info(title)
+	return info.split(' | ') if info else []
+
+
+class TestAudioLangDetection(unittest.TestCase):
+
+	def test_eng_tagged(self):
+		self.assertIn('ENG', _info_tags('Some.Movie.2023.1080p.ENG.WEB-DL.x264'))
+
+	def test_english_word_tagged(self):
+		self.assertIn('ENG', _info_tags('Some.Movie.2023.English.1080p.BluRay'))
+
+	def test_eng_subs_not_tagged(self):
+		self.assertNotIn('ENG', _info_tags('Some.Movie.2023.1080p.WEB.Eng.Subs.x264'))
+
+	def test_subs_eng_not_tagged(self):
+		self.assertNotIn('ENG', _info_tags('Some.Movie.2023.1080p.WEB.Subs.Eng.x264'))
+
+	def test_engsub_not_tagged(self):
+		self.assertNotIn('ENG', _info_tags('Some.Movie.2023.1080p.WEB.EngSub.x264'))
+
+	def test_swesub_not_swedish_false_positive(self):
+		tags = _info_tags('Some.Movie.2023.1080p.SweSub.x264')
+		self.assertNotIn('ENG', tags)
+		self.assertIn('SUBS', tags)
+
+	def test_subita_not_italian(self):
+		self.assertNotIn('ITA', _info_tags('Some.Movie.2023.1080p.SubITA.x264'))
+
+	def test_dual_audio_pair_tags_both_and_multi(self):
+		tags = _info_tags('Some.Movie.2023.1080p.ITA.ENG.BluRay.x264')
+		self.assertIn('ITA', tags)
+		self.assertIn('ENG', tags)
+		self.assertIn('MULTI-LANG', tags)
+
+	def test_each_language_positive_pattern(self):
+		samples = {
+			'ENG': 'Movie.2023.1080p.ENG.WEB', 'SPA': 'Movie.2023.1080p.Spanish.WEB', 'FRE': 'Movie.2023.1080p.TRUEFRENCH.WEB',
+			'GER': 'Movie.2023.1080p.German.WEB', 'ITA': 'Movie.2023.1080p.iTA.WEB', 'POR': 'Movie.2023.1080p.Dublado.WEB',
+			'HIN': 'Movie.2023.1080p.Hindi.WEB', 'JPN': 'Movie.2023.1080p.JPN.WEB', 'KOR': 'Movie.2023.1080p.Korean.WEB',
+			'RUS': 'Movie.2023.1080p.RUS.WEB'}
+		for tag, title in samples.items():
+			with self.subTest(tag=tag):
+				self.assertIn(tag, _info_tags(title))
+
+	def test_plain_title_no_language_tags(self):
+		tags = _info_tags('Some.Movie.2023.1080p.BluRay.x264-GROUP')
+		for _, tag in EXPECTED_LANGS:
+			self.assertNotIn(tag, tags)
+
+
+class TestSourceFilters(unittest.TestCase):
+
+	def test_source_filters_contains_all_language_entries(self):
+		filters = source_utils.source_filters()
+		for name, tag in EXPECTED_LANGS:
+			self.assertIn((name, tag), filters)
+
+	def test_audio_lang_choices_shape(self):
+		choices = source_utils.audio_lang_choices()
+		self.assertEqual(tuple((name, tag) for name, tag, _ in choices), EXPECTED_LANGS)
+		for _, _, patterns in choices:
+			self.assertTrue(patterns)
+			for pattern in patterns:
+				self.assertTrue(pattern.startswith('.') and pattern.endswith('.'))
+
+
+if __name__ == '__main__':
+	unittest.main()


### PR DESCRIPTION
**What**

Fixes #20, the issue only reports for english but I figured it would be good to cover more bases 

Adds audio-track language options to Red Light's custom Sort To Top (preferred filters). Ten languages selectable under Choose Sort To Top Parameters: ENGLISH, SPANISH, FRENCH, GERMAN, ITALIAN, PORTUGUESE, HINDI, JAPANESE, KOREAN, RUSSIAN AUDIO.

**Behaviour**

- No language param selected (default): no change to current behaviour.
- Language param selected: releases explicitly tagged with that audio language (e.g. `.ENG.`, `.English.`, dual-audio `ITA.ENG`) sort to top within each quality group.
- Same entries appear in the results window Filter Results dialog for one-off filtering.
- Language tags (ENG, SPA, …) show in each source's extra info line.
- Subtitle markers (`Eng.Subs`, `Subs.Eng`, `EngSub`, `SweSub`, `SubITA`) not treated as audio.
- Untagged releases (most English ones) unaffected — no false "English" inference.

**Changes**

- `source_utils.py`: new `audio_lang_choices()` (single source of truth), language tag detection in `get_info()` with subtitle guard, ten entries appended to `source_filters()`.
- `sources.py`: `_normalize_pref_tag()` aliases for the new language names.
- `tests/test_source_utils_audio_lang.py`: 12 tests — detection, subtitle guards, dual-audio, filter entries.
