### PR TITLE
fix: Add date label format options for Trakt Calendar

### DIFF
--- a/plugin.video.redlight/resources/lib/caches/settings_cache.py
+++ b/plugin.video.redlight/resources/lib/caches/settings_cache.py
@@ -1053,6 +1053,7 @@ def default_settings():
 {'setting_id': 'trakt.calendar_display', 'setting_type': 'action', 'setting_default': '0', 'settings_options': {'0': 'TITLE: SxE - EPISODE', '1': 'SxE - EPISODE', '2': 'EPISODE'}},
 {'setting_id': 'trakt.calendar_display_widget', 'setting_type': 'action', 'setting_default': '1', 'settings_options': {'0': 'TITLE: SxE - EPISODE', '1': 'SxE - EPISODE', '2': 'EPISODE'}},
 {'setting_id': 'trakt.calendar_sort_order', 'setting_type': 'action', 'setting_default': '0', 'settings_options': {'0': 'Descending', '1': 'Ascending'}},
+{'setting_id': 'trakt.calendar_date_labels', 'setting_type': 'action', 'setting_default': '0', 'settings_options': {'0': 'Words (Today, Tomorrow, Weekday)', '1': 'MM/DD/YYYY', '2': 'DD/MM/YYYY', '3': 'YYYY-MM-DD'}},
 {'setting_id': 'trakt.calendar_previous_days', 'setting_type': 'action', 'setting_default': '7', 'min_value': '0', 'max_value': '14'},
 {'setting_id': 'trakt.calendar_future_days', 'setting_type': 'action', 'setting_default': '7', 'min_value': '0', 'max_value': '14'},
 

--- a/plugin.video.redlight/resources/lib/indexers/episodes.py
+++ b/plugin.video.redlight/resources/lib/indexers/episodes.py
@@ -220,8 +220,12 @@ def build_single_episode(list_type, params={}):
 				else: highlight_start, highlight_end = '', ''
 				display = '%s%s%s%s%s%s' % (display_premiered, title_str, highlight_start, seas_ep, ep_name, highlight_end)
 			elif list_type_compare == 'trakt_calendar':
-				if episode_date: display_premiered = make_day(current_date, episode_date)
-				else: display_premiered = 'UNKNOWN'
+				if not episode_date:
+					display_premiered = 'UNKNOWN'
+				elif calendar_date_format:
+					display_premiered = make_day(current_date, episode_date, calendar_date_format, use_words=False)
+				else:
+					display_premiered = make_day(current_date, episode_date)
 				display = '[%s] %s%s%s' % (display_premiered, title_str, seas_ep, ep_name)
 			else: display = '%s%s%s' % (title_str, seas_ep, ep_name)
 			if no_spoilers and not playcount: thumb, plot = show_landscape or show_fanart, tvshow_plot or '* Hidden to Prevent Spoilers *'
@@ -306,8 +310,10 @@ def build_single_episode(list_type, params={}):
 	watched_indicators = settings.watched_indicators()
 	if list_type == 'episode.trakt':
 		display_format = settings.calendar_display_format(is_external)
+		calendar_date_format = settings.calendar_date_format()
 	else:
 		display_format = settings.single_ep_display_format(is_external)
+		calendar_date_format = None
 	current_date, current_time, adjust_hours = get_datetime(), get_current_timestamp(), settings.date_offset()
 	unwatched_info = settings.single_ep_unwatched_episodes()
 	hide_watched = is_external and settings.widget_hide_watched() and list_type != 'episode.recently_watched'
@@ -395,7 +401,7 @@ def build_single_episode(list_type, params={}):
 			except:
 				item_list = [i for i in item_list if i.get('first_aired') not in (None, 'None', '')]
 				item_list = sorted(item_list, key=lambda i: i.get('first_aired'), reverse=reverse)
-			if list_type_compare == 'trakt_calendar':
+			if list_type_compare == 'trakt_calendar' and not calendar_date_format:
 				airing_today = sorted([i for i in item_list if date_difference(current_date, jsondate_to_datetime(i.get('first_aired', '2100-12-31'), '%Y-%m-%d').date(), 0)],
 										key=lambda i: i['first_aired'])
 				item_list = [i for i in item_list if not i in airing_today]

--- a/plugin.video.redlight/resources/lib/modules/settings.py
+++ b/plugin.video.redlight/resources/lib/modules/settings.py
@@ -938,6 +938,13 @@ def widget_hide_watched():
 def calendar_sort_order():
 	return int(get_setting('redlight.trakt.calendar_sort_order', '0'))
 
+def calendar_date_format():
+	# None means word labels (Today, Tomorrow, weekday names)
+	formats = {1: '%m/%d/%Y', 2: '%d/%m/%Y', 3: '%Y-%m-%d'}
+	try: choice = int(get_setting('redlight.trakt.calendar_date_labels', '0'))
+	except (TypeError, ValueError): return None
+	return formats.get(choice)
+
 def ignore_articles():
 	return get_setting('redlight.ignore_articles', 'false') == 'true'
 

--- a/plugin.video.redlight/resources/skins/Default/1080i/settings_manager.xml
+++ b/plugin.video.redlight/resources/skins/Default/1080i/settings_manager.xml
@@ -1551,6 +1551,14 @@
                       </item>
                       <item>
                           <visible>Container(2000).HasFocus(40)</visible>
+                          <property name="setting_label">Calendar Date Labels</property>
+                          <property name="setting_type">action</property>
+                          <property name="setting_value">$INFO[Window(10000).Property(redlight.trakt.calendar_date_labels_name)]</property>
+                          <property name="setting_description">Choose how Red Light labels the airdate of episodes in the Trakt Calendar. Words uses Today, Tomorrow and weekday names. The date formats always show the full date, keeping the list in plain chronological order</property>
+                          <onclick>RunPlugin(plugin://plugin.video.redlight/?mode=settings_manager.set_from_list&amp;setting_id=trakt.calendar_date_labels)</onclick>
+                      </item>
+                      <item>
+                          <visible>Container(2000).HasFocus(40)</visible>
                           <property name="setting_label">Sort Order</property>
                           <property name="setting_type">action</property>
                           <property name="setting_value">$INFO[Window(10000).Property(redlight.trakt.calendar_sort_order_name)]</property>

--- a/tests/test_trakt_calendar_date_labels.py
+++ b/tests/test_trakt_calendar_date_labels.py
@@ -1,0 +1,103 @@
+import importlib.util
+import sys
+import types
+import unittest
+from datetime import date
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+UTILS_PATH = ROOT / 'plugin.video.redlight' / 'resources' / 'lib' / 'modules' / 'utils.py'
+SETTINGS_CACHE_PATH = ROOT / 'plugin.video.redlight' / 'resources' / 'lib' / 'caches' / 'settings_cache.py'
+
+STUB_MODULE_KEYS = ('modules', 'modules.kodi_utils', 'modules.settings', 'caches', 'caches.base_cache')
+
+
+def _install_stub_modules():
+	properties = {}
+	kodi_utils = types.ModuleType('modules.kodi_utils')
+	kodi_utils.addon_fanart = lambda: ''
+	kodi_utils.addon_info = lambda key: 'test-version' if key == 'version' else ''
+	kodi_utils.clear_property = lambda key: properties.pop(key, None)
+	kodi_utils.get_property = lambda key: properties.get(key, '')
+	kodi_utils.is_android = lambda: False
+	kodi_utils.logger = lambda *args, **kwargs: None
+	kodi_utils.notification = lambda *args, **kwargs: None
+	kodi_utils.path_exists = lambda path: False
+	kodi_utils.schedule_widget_refresh = lambda **kwargs: None
+	kodi_utils.set_property = lambda key, value: properties.__setitem__(key, value)
+	kodi_utils.sleep = lambda *args, **kwargs: None
+	kodi_utils.translate_path = lambda path: path
+
+	modules = types.ModuleType('modules')
+	modules.__path__ = []
+	modules.kodi_utils = kodi_utils
+	settings = types.ModuleType('modules.settings')
+	settings.max_threads = lambda: 1
+
+	caches = types.ModuleType('caches')
+	caches.__path__ = []
+	base_cache = types.ModuleType('caches.base_cache')
+	base_cache.connect_database = lambda name: None
+
+	sys.modules['modules'] = modules
+	sys.modules['modules.kodi_utils'] = kodi_utils
+	sys.modules['modules.settings'] = settings
+	sys.modules['caches'] = caches
+	sys.modules['caches.base_cache'] = base_cache
+
+
+def _load_module(name, path):
+	spec = importlib.util.spec_from_file_location(name, path)
+	module = importlib.util.module_from_spec(spec)
+	spec.loader.exec_module(module)
+	return module
+
+
+class TraktCalendarDateLabelTests(unittest.TestCase):
+	@classmethod
+	def setUpClass(cls):
+		cls._original_sys_modules = {}
+		for key in STUB_MODULE_KEYS:
+			if key in sys.modules:
+				cls._original_sys_modules[key] = sys.modules[key]
+		_install_stub_modules()
+		cls.utils = _load_module('utils_under_test', UTILS_PATH)
+		cls.settings_cache = _load_module('settings_cache_under_test_date_labels', SETTINGS_CACHE_PATH)
+
+	@classmethod
+	def tearDownClass(cls):
+		for key in STUB_MODULE_KEYS:
+			if key in cls._original_sys_modules:
+				sys.modules[key] = cls._original_sys_modules[key]
+			else:
+				sys.modules.pop(key, None)
+
+	def setUp(self):
+		self.today = date(2026, 7, 19)
+
+	def test_words_mode_uses_relative_labels(self):
+		make_day = self.utils.make_day
+		self.assertEqual('YESTERDAY', make_day(self.today, date(2026, 7, 18)))
+		self.assertEqual('TODAY', make_day(self.today, date(2026, 7, 19)))
+		self.assertEqual('TOMORROW', make_day(self.today, date(2026, 7, 20)))
+		self.assertEqual('TUESDAY', make_day(self.today, date(2026, 7, 21)))
+
+	def test_date_mode_ignores_relative_labels(self):
+		make_day = self.utils.make_day
+		self.assertEqual('07/19/2026', make_day(self.today, date(2026, 7, 19), '%m/%d/%Y', use_words=False))
+		self.assertEqual('20/07/2026', make_day(self.today, date(2026, 7, 20), '%d/%m/%Y', use_words=False))
+		self.assertEqual('2026-07-21', make_day(self.today, date(2026, 7, 21), '%Y-%m-%d', use_words=False))
+
+	def test_default_setting_metadata(self):
+		defaults = {s['setting_id']: s for s in self.settings_cache.default_settings()}
+		setting = defaults.get('trakt.calendar_date_labels')
+		self.assertIsNotNone(setting, 'trakt.calendar_date_labels missing from default settings')
+		self.assertEqual('action', setting['setting_type'])
+		self.assertEqual('0', setting['setting_default'])
+		self.assertEqual({'0': 'Words (Today, Tomorrow, Weekday)', '1': 'MM/DD/YYYY', '2': 'DD/MM/YYYY', '3': 'YYYY-MM-DD'},
+						 setting['settings_options'])
+
+
+if __name__ == '__main__':
+	unittest.main()


### PR DESCRIPTION

## What

Fixes #138 

Adds a "Calendar Date Labels" setting to the Trakt Calendar section of the Settings Manager, letting users replace the Today/Tomorrow/weekday labels with a full date in MM/DD/YYYY, DD/MM/YYYY, or YYYY-MM-DD format.

## Behaviour

- Default remains the current word labels — existing installs see no change.
- With a date format selected, every calendar entry is labelled with its full airdate (e.g. `[07/19/2026] Show: 01x05 - Episode`).
- In date mode the pin-today-to-top reordering is skipped, so the list is purely chronological per the chosen Sort Order (combined with Show Previous Days = 0 / Show Future Days = 14, this gives a clean future-only chronological calendar).
- Non-numeric stored values fall back to word labels instead of breaking calendar rendering.
- Setting is auto-inserted on upgrade via the normal settings sync; no migration needed.

## Changes

- `settings_cache.py`: new `trakt.calendar_date_labels` defaults entry
- `settings.py`: `calendar_date_format()` accessor mapping the choice to a strftime format
- `episodes.py`: wire format into `make_day`, skip today-pinning in date mode
- `settings_manager.xml`: new "Calendar Date Labels" list setting
- `tests/test_trakt_calendar_date_labels.py`: coverage for label formatting and the setting's defaults metadata
