### PR TITLE
Unified list sort: independent Movies / TV Shows sort order

### DIFF
--- a/plugin.video.redlight/resources/lib/apis/mdblist_api.py
+++ b/plugin.video.redlight/resources/lib/apis/mdblist_api.py
@@ -2,11 +2,10 @@
 import json
 import time
 import requests
-from operator import itemgetter
 from caches import mdblist_cache
 from caches.settings_cache import get_setting, set_setting
-from modules import kodi_utils, settings
-from modules.utils import sort_for_article, paginate_list, get_datetime, TaskPool, make_thread_list, copy2clip, make_qrcode, make_tinyurl
+from modules import kodi_utils, settings, list_sort
+from modules.utils import paginate_list, get_datetime, TaskPool, make_thread_list, copy2clip, make_qrcode, make_tinyurl
 
 BASE_URL = 'https://api.mdblist.com/%s'
 _OAUTH_DEVICE_URL = 'https://api.mdblist.com/oauth/device-authorization/'
@@ -571,10 +570,7 @@ def mdblist_watchlist(media_kind, page_no):
 	if original_list and not normalized:
 		kodi_utils.logger('MDBList Watchlist', 'Could not resolve TMDb ids from %s raw items' % len(original_list))
 	original_list = normalized
-	sort_key = settings.lists_sort_order('watchlist')
-	if sort_key == 2: original_list.sort(key=itemgetter('release_date'), reverse=True)
-	elif sort_key == 1: original_list.sort(key=itemgetter('watchlist_at'), reverse=True)
-	else: original_list = sort_for_article(original_list, 'title', settings.ignore_articles())
+	original_list = list_sort.sort_source(original_list, 'mdblist.watchlist', media_kind, 'mdblist_watchlist')
 	is_home = kodi_utils.external()
 	if settings.paginate(is_home): return paginate_list(original_list, page_no, settings.page_limit(is_home))
 	return original_list, 1
@@ -582,10 +578,7 @@ def mdblist_watchlist(media_kind, page_no):
 def mdblist_collection(media_kind, page_no):
 	string, url = 'mdblist_collection', 'sync/collection'
 	original_list = _mdbl_personal_list(_mdbl_collection_watchlist_items(string, url), media_kind)
-	sort_key = settings.lists_sort_order('collection')
-	if sort_key == 2: original_list.sort(key=itemgetter('year'), reverse=True)
-	elif sort_key == 1: original_list.sort(key=itemgetter('collected_at'), reverse=True)
-	else: original_list = sort_for_article(original_list, 'title', settings.ignore_articles())
+	original_list = list_sort.sort_source(original_list, 'mdblist.collection', media_kind, 'mdblist_collection')
 	is_home = kodi_utils.external()
 	if settings.paginate(is_home): return paginate_list(original_list, page_no, settings.page_limit(is_home))
 	return original_list, 1

--- a/plugin.video.redlight/resources/lib/apis/simkl_api.py
+++ b/plugin.video.redlight/resources/lib/apis/simkl_api.py
@@ -8,7 +8,7 @@ from threading import Lock
 from urllib.parse import urljoin
 from caches import simkl_cache
 from caches.settings_cache import get_setting, set_setting
-from modules import kodi_utils, settings
+from modules import kodi_utils, settings, list_sort
 from modules.utils import copy2clip, make_qrcode
 
 BASE_URL = 'https://api.simkl.com'
@@ -266,7 +266,12 @@ def _simkl_fetch_status_live(media_kind, status):
 			'released': _simkl_release_key(item, media_kind)})
 	if skipped and not result:
 		kodi_utils.logger('Simkl', 'list %s/%s: %s items had no tmdb/imdb/tvdb ids' % (media_kind, status, skipped))
-	try: return settings.sort_simkl_personal_list(result)
+	# 'anime' is only ever fetched by _simkl_fetch_tv_status, which merges it with the shows list and
+	# sorts the merged result under an explicit 'shows'. Sorting here too would resolve to
+	# DEFAULT_SPEC ('anime' does not normalize to a mediatype, so there is no scope suffix and no
+	# override) and break the final sort's ties alphabetically instead of preserving Simkl's order.
+	if media_kind == 'anime': return result
+	try: return list_sort.sort_source(result, 'simkl', media_kind, 'simkl')
 	except Exception as e:
 		kodi_utils.logger('Simkl', 'sort %s/%s failed: %s' % (media_kind, status, e))
 		return result
@@ -280,9 +285,8 @@ def _simkl_fetch_tv_status(status):
 	shows = _simkl_fetch_status('shows', status)
 	anime = _simkl_fetch_status('anime', status)
 	if not shows and not anime: return []
-	combined = shows + anime
-	try: return settings.sort_simkl_personal_list(combined)
-	except: return combined
+	# sort_source never raises, so no guard here: a bare except would only swallow KeyboardInterrupt.
+	return list_sort.sort_source(shows + anime, 'simkl', 'shows', 'simkl')
 
 def simkl_plantowatch(media_kind, page_no=None):
 	if media_kind == 'shows': return _simkl_fetch_tv_status('plantowatch')

--- a/plugin.video.redlight/resources/lib/apis/trakt_api.py
+++ b/plugin.video.redlight/resources/lib/apis/trakt_api.py
@@ -12,9 +12,9 @@ def _trakt_setting(setting_id, fallback=''):
 	return val
 from caches.main_cache import cache_object
 from caches.lists_cache import lists_cache_object
-from modules import kodi_utils, settings
+from modules import kodi_utils, settings, list_sort
 from modules.metadata import movie_meta_external_id, tvshow_meta_external_id
-from modules.utils import sort_list, sort_for_article, get_datetime, timedelta, replace_html_codes, copy2clip, make_qrcode, make_tinyurl, \
+from modules.utils import get_datetime, timedelta, replace_html_codes, copy2clip, make_qrcode, make_tinyurl, \
 							TaskPool, jsondate_to_datetime as js2date
 # logger = kodi_utils.logger
 
@@ -460,7 +460,7 @@ def trakt_watchlist_lists(media_type, list_type=None):
 
 def trakt_collection(media_type, dummy_arg):
 	data = trakt_fetch_collection_watchlist('collection', media_type)
-	return settings.sort_trakt_sync_list(data, 'collection')
+	return list_sort.sort_source(data, 'trakt.collection', media_type, 'trakt_sync')
 
 def trakt_watchlist(media_type, dummy_arg):
 	data = trakt_fetch_collection_watchlist('watchlist', media_type)
@@ -468,8 +468,7 @@ def trakt_watchlist(media_type, dummy_arg):
 		current_date = get_datetime()
 		str_format = '%Y-%m-%d' if media_type in ('movie', 'movies') else '%Y-%m-%dT%H:%M:%S.%fZ'
 		data = [i for i in data if i.get('released', None) and js2date(i.get('released'), str_format, remove_time=True) <= current_date]
-	data = settings.sort_trakt_sync_list(data, 'watchlist')
-	return data
+	return list_sort.sort_source(data, 'trakt.watchlist', media_type, 'trakt_sync')
 
 def trakt_fetch_collection_watchlist(list_type, media_type):
 	def _process(params):
@@ -695,12 +694,15 @@ def trakt_lists_with_media(media_type, imdb_id):
 	params = {'path': '%s/%s/lists/personal', 'path_insert': (media_type, imdb_id), 'params': {'limit': 100}, 'pagination': False}
 	return cache_object(_process, string, 'foo', False, 168)
 
-def get_trakt_list_contents(list_type, user, slug, with_auth, list_id=None, sort_by='default', sort_how='default'):
-	if sort_by == 'skip': skip_sort, custom_sort, method = True, False, None
-	else:
-		skip_sort = False
-		custom_sort = sort_by != 'default'
-		method = None if custom_sort else 'sort_by_headers'
+def get_trakt_list_contents(list_type, user, slug, with_auth, list_id=None, skip_sort=False):
+	# skip_sort is the random builders' flag: they reshuffle the payload themselves, so resolving
+	# and applying a sort first is wasted work. Everything else takes the list's own ordering.
+	# There is deliberately no caller-supplied sort: the ordering comes from the payload headers
+	# below and from the stored override, never from an argument. A parameter that could select a
+	# different `method` is what let two callers write two shapes into one cache key.
+	# Always ask for the sort headers. The disk cache key below does not encode `method`, so a row
+	# written by one caller is read back by all of them.
+	method = 'sort_by_headers'
 	if list_type == 'my_lists':
 		string = 'trakt_list_contents_%s_%s_%s' % (list_type, user, slug)
 		params = {'path': 'users/%s/lists/%s/items', 'path_insert': (user, slug), 'params': {'extended': 'full'}, 'method': method, 'with_auth': with_auth, 'fetch_all': True}
@@ -712,17 +714,30 @@ def get_trakt_list_contents(list_type, user, slug, with_auth, list_id=None, sort
 		if user == 'Trakt Official': params = {'path': 'lists/%s/items', 'path_insert': slug, 'params': {'extended': 'full'}, 'method': method, 'fetch_all': True}
 		else: params = {'path': 'users/%s/lists/%s/items', 'path_insert': (user, slug), 'params': {'extended': 'full'}, 'method': method, 'with_auth': with_auth, 'fetch_all': True}
 	data = trakt_cache.cache_trakt_object(get_trakt, string, params) or []
+	# The list's declared order, as recorded in the cached row. 'default' is the standing-in value
+	# for a legacy bare-list row that carries no headers at all.
+	sort_by, sort_how = 'default', 'default'
+	# Unwrapped unconditionally, including when skip_sort is set: a cache row left behind by an
+	# older build, or by any caller at all, must never reach the enumerate() below as a dict.
+	if isinstance(data, dict):
+		sort_by, sort_how = data.get('sort_by', sort_by), data.get('sort_how', sort_how)
+		data = data.get('data') or []
+	elif not isinstance(data, list): data = []
 	if not skip_sort:
-		if not custom_sort:
-			if isinstance(data, dict) and 'data' in data:
-				sort_by, sort_how = data['sort_by'], data['sort_how']
-				data = data['data'] or []
-			elif not isinstance(data, list): data = []
+		# Guarded per item, like the extraction loop below: a season or episode row that is missing
+		# 'show' is one bad row, and it must cost that row its retitling, not the whole list render.
 		for i in data:
-			if i['type'] == 'season': i['season']['title'] = '%s - %s' % (i['show']['title'], i['season']['title'])
-			elif i['type'] == 'episode': i['episode']['title'] = '%s - %s' % (i['show']['title'], i['episode']['title'])
-			else: pass
-		data = sort_list(sort_by, sort_how, data, settings.ignore_articles())
+			try:
+				if i['type'] == 'season': i['season']['title'] = '%s - %s' % (i['show']['title'], i['season']['title'])
+				elif i['type'] == 'episode': i['episode']['title'] = '%s - %s' % (i['show']['title'], i['episode']['title'])
+				else: pass
+			except: pass
+		# The payload sort is the ordering this list already had, so it is what a list with no stored
+		# override must keep - resolving to DEFAULT_SPEC here would retitle-sort every user list
+		# belonging to anyone who never opened "Set Custom Sort", with no row left to migrate.
+		payload_spec = list_sort.trakt_list_fallback(sort_by, sort_how)
+		data = list_sort.sort_source(data, 'trakt.list:%s' % list_id, None, 'trakt_list', fallback=payload_spec) if list_id is not None \
+			else list_sort.apply(data, list_sort.parse_spec(payload_spec), list_sort.TRAKT_LIST, settings.ignore_articles())
 	results = []
 	results_append = results.append
 	for c, i in enumerate(data):

--- a/plugin.video.redlight/resources/lib/caches/base_cache.py
+++ b/plugin.video.redlight/resources/lib/caches/base_cache.py
@@ -67,7 +67,9 @@ expires integer, unique (provider, db_type, tmdb_id, title, year, season, episod
 'tmdb_lists_db': (
 'CREATE TABLE IF NOT EXISTS tmdb_lists (id text unique, data text, expires integer)',),
 'random_widgets_db': (
-'CREATE TABLE IF NOT EXISTS random_widgets (id text unique, data text, expires integer)',)
+'CREATE TABLE IF NOT EXISTS random_widgets (id text unique, data text, expires integer)',),
+'list_sort_db': (
+'CREATE TABLE IF NOT EXISTS list_sort (scope text unique, spec text)',)
 		}
 
 def locations():
@@ -75,7 +77,7 @@ def locations():
 'navigator_db': 'navigator.db', 'watched_db': 'watched.db', 'favorites_db': 'favourites.db', 'settings_db': 'settings.db', 'trakt_db': 'traktcache.db', 'simkl_db': 'simklcache.db', 'mdblist_db': 'mdblistcache.db',
 'maincache_db': 'maincache.db', 'metacache_db': 'metacache.db', 'debridcache_db': 'debridcache.db', 'lists_db': 'lists.db', 'tmdb_lists_db': 'tmdb_lists.db',
 'discover_db': 'discover.db', 'external_db': 'external.db', 'episode_groups_db': 'episode_groups.db', 'personal_lists_db': 'personal_lists.db',
-'random_widgets_db': 'random_widgets.db'
+'random_widgets_db': 'random_widgets.db', 'list_sort_db': 'list_sort.db'
 			}
 
 def database_locations(database_name):
@@ -128,8 +130,10 @@ def get_timestamp(offset=0):
 
 def remove_old_databases():
 	databases_path = path.join(kodi_utils.addon_profile(), 'databases/')
-	current_dbs = ('navigator.db', 'watched.db', 'favourites.db', 'traktcache.db', 'simklcache.db', 'mdblistcache.db', 'maincache.db', 'lists.db', 'tmdb_lists.db', 'discover.db',
-	'metacache.db', 'debridcache.db', 'external.db', 'settings.db', 'episode_groups.db', 'personal_lists_db', 'episode_groups_db', 'personal_lists_db', 'random_widgets_db')
+	# Derived from locations() rather than hand-maintained: the hand-written list had drifted and
+	# carried four database *keys* where filenames belong, which put personal_lists.db and
+	# random_widgets.db outside the allowlist and marked both live files as stale.
+	current_dbs = tuple(locations().values())
 	try:
 		files = kodi_utils.list_dirs(databases_path)[1]
 		for item in files:
@@ -142,7 +146,8 @@ def check_databases_integrity(silent=False):
 	integrity_check = {
 	'settings_db': 1,              'navigator_db': 1,              'watched_db': 3,              'favorites_db': 1,              'trakt_db': 4,              'simkl_db': 4,              'mdblist_db': 4,
 	'maincache_db': 1,             'metacache_db': 3,              'lists_db': 1,                'tmdb_lists_db': 1,             'discover_db': 1,
-	'debridcache_db': 1,           'external_db': 1,               'episode_groups_db': 1,       'personal_lists_db': 1,         'random_widgets_db': 1
+	'debridcache_db': 1,           'external_db': 1,               'episode_groups_db': 1,       'personal_lists_db': 1,         'random_widgets_db': 1,
+	'list_sort_db': 1
 			}
 	def _process(database_name, tables):
 		cursor, error = None, False

--- a/plugin.video.redlight/resources/lib/caches/list_sort_cache.py
+++ b/plugin.video.redlight/resources/lib/caches/list_sort_cache.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+"""Single home for per-list sort overrides.
+
+Rows exist only when a user has overridden a list. Absence means 'fall through
+to the mediatype default'. Cannot live in settings.db: sync_settings() purges
+any setting id missing from default_settings().
+"""
+from caches.base_cache import connect_database
+
+MOVIES, SHOWS = 'movies', 'shows'
+
+_MEDIA_TYPES = {'movie': MOVIES, 'movies': MOVIES, 'show': SHOWS, 'shows': SHOWS, 'tvshow': SHOWS, 'tvshows': SHOWS}
+
+
+def normalize_media_type(media_type):
+	"""'movie'/'movies' -> 'movies'; 'show'/'shows'/'tvshow' -> 'shows'; anything else -> ''."""
+	if not media_type: return ''
+	return _MEDIA_TYPES.get(str(media_type).lower(), '')
+
+
+def scope_key(list_key, media_type=None):
+	"""Mediatype-split lists get a ':movies'/':shows' suffix. Mixed lists do not."""
+	normalized = normalize_media_type(media_type)
+	if not normalized: return list_key
+	return '%s:%s' % (list_key, normalized)
+
+
+def get_override(scope):
+	try:
+		dbcon = connect_database('list_sort_db')
+		row = dbcon.execute('SELECT spec FROM list_sort WHERE scope = ?', (scope,)).fetchone()
+		if not row: return ''
+		return row[0] or ''
+	except: return ''
+
+
+def get_all_overrides():
+	try:
+		dbcon = connect_database('list_sort_db')
+		rows = dbcon.execute('SELECT scope, spec FROM list_sort').fetchall()
+		return dict((i[0], i[1] or '') for i in rows)
+	except: return {}
+
+
+def set_override(scope, spec_string):
+	try:
+		dbcon = connect_database('list_sort_db')
+		dbcon.execute('INSERT OR REPLACE INTO list_sort (scope, spec) VALUES (?, ?)', (scope, spec_string))
+		return True
+	except: return False
+
+
+def delete_override(scope):
+	try:
+		dbcon = connect_database('list_sort_db')
+		dbcon.execute('DELETE FROM list_sort WHERE scope = ?', (scope,))
+		return True
+	except: return False

--- a/plugin.video.redlight/resources/lib/caches/personal_lists_cache.py
+++ b/plugin.video.redlight/resources/lib/caches/personal_lists_cache.py
@@ -83,6 +83,16 @@ class PersonalListsCache:
 			return 'Success'
 		except: return 'Error'
 
+	def get_all_sort_orders(self):
+		"""Every list's stored sort_order. Raises on a locked database - deliberately, unlike its
+		neighbours: its only caller is the one-time sort migration, which must be able to tell an
+		empty store from an unreadable one. Returning {} on failure would look like a clean success,
+		let the migration record itself as done, and delete every stored preference on the next sync.
+		"""
+		dbcon = connect_database('personal_lists_db')
+		rows = dbcon.execute('SELECT name, author, sort_order FROM personal_lists').fetchall()
+		return dict(((i[0], i[1]), i[2]) for i in rows)
+
 	def get_list_names_and_authors(self):
 		data = self.get_lists()
 		return [(i['name'], i['author']) for i in data]

--- a/plugin.video.redlight/resources/lib/caches/settings_cache.py
+++ b/plugin.video.redlight/resources/lib/caches/settings_cache.py
@@ -75,8 +75,18 @@ def _new_settings_affect_widgets(insert_list):
 		return True
 	return False
 
-def _new_setting_value(setting_id, setting_default, currentsettings, had_existing_settings):
+def _new_setting_value(setting_id, setting_default, currentsettings, had_existing_settings, fresh_install=False) -> str:
 	if not had_existing_settings:
+		# A genuine fresh install has nothing to migrate, but migrate_legacy_sort_settings() reads each
+		# absent legacy id as its own old getter fallback, so it would write six override rows for a user
+		# who has never touched a sort setting - breaking list_sort_cache's "a row means the user
+		# overrode this list" invariant. Seed the sentinel as already done so it never runs here.
+		#
+		# fresh_install, not had_existing_settings: the caller's dict comes from get_all(), which
+		# answers {} for a locked or corrupt database too. Seeding 'true' on that mistake would skip the
+		# migration forever - the next healthy sync reads the sentinel, never runs it, and the obsolete
+		# purge then deletes the five legacy ids and with them the only copy of the user's orderings.
+		if setting_id == 'migration.unified_list_sort': return 'true' if fresh_install else setting_default
 		return setting_default
 	old_setting_id = _NEW_SETTING_VALUE_MIGRATIONS.get(setting_id)
 	if not old_setting_id:
@@ -237,6 +247,23 @@ class SettingsCache:
 		try: all_settings = dict(dbcon.execute('SELECT setting_id, setting_value FROM settings').fetchall())
 		except: all_settings = {}
 		return all_settings
+
+	def is_empty_strict(self):
+		"""True only when this profile genuinely holds no settings. Raises rather than guessing.
+
+		get_all() swallows every sqlite error and answers {}, so its empty dict cannot tell a fresh
+		install from a database that is locked, corrupt or unreadable. Anything deciding "this profile
+		has never been written to" has to ask a question that is allowed to fail. An absent file and an
+		absent table are both genuinely empty - the service creates them on first run.
+		"""
+		from caches.base_cache import database_locations
+		if not kodi_utils.path_exists(database_locations('settings_db')): return True
+		dbcon = connect_database('settings_db')
+		try: row = dbcon.execute('SELECT setting_id FROM settings LIMIT 1').fetchone()
+		except Exception as error:
+			if 'no such table' in str(error).lower(): return True
+			raise
+		return row is None
 
 	def set(self, setting_id, setting_value=None):
 		setting_id = setting_id.replace('redlight.', '')
@@ -507,6 +534,13 @@ _DIRECTORY_LISTING_MODES = frozenset((
 	'build_in_progress_episode', 'build_recently_watched_episode', 'build_next_episode',
 	'build_my_calendar', 'build_next_episode_manager'))
 
+# The five settings the unified-list-sort migration reads. They are no longer in default_settings(),
+# so the obsolete-id purge in sync_settings() would delete them on the same pass that migrates them -
+# leaving nothing to retry from if the migration fails. The purge is deferred until the sentinel says
+# the migration succeeded, which happens in the same run, so they are removed on the following sync.
+_LEGACY_SORT_SETTING_IDS = frozenset((
+	'sort.watchlist', 'sort.collection', 'sort.simkl', 'tmdbsort.watchlist', 'tmdbsort.favorites'))
+
 def is_directory_listing_mode(mode):
 	if not mode: return False
 	if mode.startswith('navigator.'): return True
@@ -571,13 +605,29 @@ def sync_settings(params={}):
 	insert_list = []
 	insert_list_append = insert_list.append
 	currentsettings = settings_cache.get_all()
+	# Redundant by design: the obsolete purge below defers the legacy sort ids until the migration has
+	# recorded success, so currentsettings still holds them when the migration runs. This pre-purge
+	# snapshot is the second line of defence if that deferral is ever removed - keep both.
+	legacy_sort_settings = {k: v for k, v in currentsettings.items() if k.startswith('sort.') or k.startswith('tmdbsort.')}
 	had_existing_settings = bool(currentsettings)
+	# Only a database that answers "no rows" without erroring is a fresh install. A failure here is
+	# treated as "not fresh", which defers the sort migration to the next sync instead of cancelling
+	# it: the sentinel stays 'false' and the obsolete purge keeps holding the legacy ids back.
+	fresh_install = False
+	if not had_existing_settings:
+		try: fresh_install = settings_cache.is_empty_strict()
+		except Exception as error:
+			kodi_utils.logger('sync_settings', 'settings db not readable, deferring sort migration: %s' % error)
 	d_settings = default_settings()
 	defaultsettings_ids = _defaultsettings_ids(d_settings)
 	defaults_map = {i['setting_id']: i for i in d_settings}
 	try:
 		c_settings = currentsettings.items()
-		obsoletesettings_ids = [k for k, v in c_settings if not k in defaultsettings_ids]
+		# Keep the legacy sort ids alive until the migration below has actually recorded success,
+		# otherwise a failed run purges the only copy of the user's per-list orderings.
+		defer_legacy_sort = currentsettings.get('migration.unified_list_sort') != 'true'
+		obsoletesettings_ids = [k for k, v in c_settings
+			if not k in defaultsettings_ids and not (defer_legacy_sort and k in _LEGACY_SORT_SETTING_IDS)]
 		if obsoletesettings_ids:
 			for item in obsoletesettings_ids: settings_cache.remove_setting(item)
 			migrated = True
@@ -645,6 +695,51 @@ def sync_settings(params={}):
 			settings_cache.write_db('migration.my_content_nav_mode_v136', 'true', defaults_map.get('migration.my_content_nav_mode_v136'))
 			currentsettings['migration.my_content_nav_mode_v136'] = 'true'
 			if load_properties: settings_cache.set_memory_cache('migration.my_content_nav_mode_v136', 'true')
+		if currentsettings.get('migration.unified_list_sort') != 'true':
+			# Only record the migration as done when it did not raise. The obsolete purge above
+			# holds back the five legacy sort ids while this sentinel is unset, so a failed run
+			# leaves both the sentinel and the source values in place and the next sync retries
+			# for real. They are purged on that following sync, once the sentinel is 'true'.
+			sort_migration_ok = True
+			try:
+				from modules.list_sort import run_sort_migration
+				def _write_sort_setting(setting_id, value):
+					settings_cache.write_db(setting_id, value, defaults_map.get(setting_id))
+					currentsettings[setting_id] = value
+					if load_properties: settings_cache.set_memory_cache(setting_id, value)
+				if run_sort_migration(legacy_sort_settings, _write_sort_setting): migrated = True
+				try:
+					# The _strict getters raise instead of returning {} on a locked database or a corrupt
+					# row. Their swallowing siblings, which the UI uses, would report "nothing stored"
+					# and let the sentinel be written over preferences that were never read.
+					from caches.trakt_cache import get_all_lists_custom_sort_strict
+					from caches.tmdb_lists import tmdb_lists_cache
+					from caches.list_sort_cache import set_override
+					from modules.list_sort import migrate_legacy_stores
+					from caches.personal_lists_cache import personal_lists_cache
+					personal_rows = personal_lists_cache.get_all_sort_orders()
+					store_overrides = migrate_legacy_stores(get_all_lists_custom_sort_strict(), personal_rows, tmdb_lists_cache.get_sort_orders_strict())
+					failed = [scope for scope, spec_string in store_overrides.items() if not set_override(scope, spec_string)]
+					if store_overrides: migrated = True
+					if failed:
+						sort_migration_ok = False
+						kodi_utils.logger('sync_settings', 'legacy sort store migration: could not persist %s' % ', '.join(sorted(failed)))
+				except Exception as e:
+					# Swallowing this would write the sentinel on a run that saved nothing, and the per-list
+					# Trakt, personal and TMDb preferences are deleted with the legacy ids on the next sync.
+					# Fold it into the outer flag instead so the sentinel stays unset and the next sync retries.
+					sort_migration_ok = False
+					kodi_utils.logger('sync_settings', 'legacy sort store migration: %s' % e)
+			except Exception as e:
+				# Deliberately catches an ImportError on modules.list_sort too: the sentinel stays false, so a
+				# genuinely broken install retries and logs on every sync rather than once. Do not narrow this.
+				sort_migration_ok = False
+				migrated = True # a partial run may already have written the mediatype defaults
+				kodi_utils.logger('sync_settings', 'unified list sort migration: %s' % e)
+			if sort_migration_ok:
+				settings_cache.write_db('migration.unified_list_sort', 'true', defaults_map.get('migration.unified_list_sort'))
+				currentsettings['migration.unified_list_sort'] = 'true'
+				if load_properties: settings_cache.set_memory_cache('migration.unified_list_sort', 'true')
 		for setting_id, value in list(currentsettings.items()):
 			if setting_id not in defaults_map: continue
 			sanitized = sanitize_setting_value(setting_id, value, defaults_map[setting_id], validate_paths=False)
@@ -661,7 +756,7 @@ def sync_settings(params={}):
 			continue
 		setting_type = item['setting_type']
 		setting_default = item['setting_default']
-		setting_value = _new_setting_value(setting_id, setting_default, currentsettings, had_existing_settings)
+		setting_value = _new_setting_value(setting_id, setting_default, currentsettings, had_existing_settings, fresh_install)
 		if setting_type == 'action' and 'settings_options' in item:
 			if setting_id == 'aiostreams.instance':
 				try:
@@ -1001,16 +1096,11 @@ def default_settings():
 #==================== Contents Sort Order For Watched Progress
 {'setting_id': 'sort.progress', 'setting_type': 'action', 'setting_default': '0', 'settings_options': {'0': 'Title', '1': 'Recently Watched'}},
 {'setting_id': 'sort.watched', 'setting_type': 'action', 'setting_default': '0', 'settings_options': {'0': 'Title', '1': 'Recently Watched'}},
-#==================== Contents Sort Order For Simkl Lists
-{'setting_id': 'sort.simkl', 'setting_type': 'action', 'setting_default': '0', 'settings_options': {'0': 'Title', '1': 'Date Added (desc)', '2': 'Release Date (desc)', '3': 'Date Added (asc)', '4': 'Release Date (asc)'}},
-#==================== Contents Sort Order For Trakt Lists
-{'setting_id': 'sort.collection', 'setting_type': 'action', 'setting_default': '0', 'settings_options': {'0': 'Title', '1': 'Date Added (desc)', '2': 'Release Date (desc)', '3': 'Date Added (asc)', '4': 'Release Date (asc)'}},
-{'setting_id': 'sort.watchlist', 'setting_type': 'action', 'setting_default': '0', 'settings_options': {'0': 'Title', '1': 'Date Added (desc)', '2': 'Release Date (desc)', '3': 'Date Added (asc)', '4': 'Release Date (asc)'}},
-#==================== Contents Sort Order For TMDb Lists
-{'setting_id': 'tmdbsort.watchlist', 'setting_type': 'action', 'setting_default': '4', 'settings_options': {'0': 'Title', '1': 'Release Date (asc)', '2': 'Release Date (desc)',
-'3': 'Shuffle', '4': 'Default from TMDb (None)'}},
-{'setting_id': 'tmdbsort.favorites', 'setting_type': 'action', 'setting_default': '4', 'settings_options': {'0': 'Title', '1': 'Release Date (asc)', '2': 'Release Date (desc)',
-'3': 'Shuffle', '4': 'Default from TMDb (None)'}},
+#==================== Contents Sort Order Defaults (per media type, all lists)
+{'setting_id': 'sort.default.movies', 'setting_type': 'string', 'setting_default': 'title:asc'},
+{'setting_id': 'sort.default.movies_name', 'setting_type': 'name', 'setting_default': 'Title (ascending)'},
+{'setting_id': 'sort.default.shows', 'setting_type': 'string', 'setting_default': 'title:asc'},
+{'setting_id': 'sort.default.shows_name', 'setting_type': 'name', 'setting_default': 'Title (ascending)'},
 #==================== Personal Lists
 {'setting_id': 'personal_list.sort_unseen_to_top', 'setting_type': 'boolean', 'setting_default': 'true'},
 {'setting_id': 'personal_list.highlight_unseen', 'setting_type': 'boolean', 'setting_default': 'false'},
@@ -1107,6 +1197,7 @@ def default_settings():
 {'setting_id': 'migration.cache_check_pm_oc_tb_v129e', 'setting_type': 'boolean', 'setting_default': 'false'},
 {'setting_id': 'migration.ad_cache_check_removed_v173', 'setting_type': 'boolean', 'setting_default': 'false'},
 {'setting_id': 'migration.my_content_nav_mode_v136', 'setting_type': 'boolean', 'setting_default': 'false'},
+{'setting_id': 'migration.unified_list_sort', 'setting_type': 'boolean', 'setting_default': 'false'},
 #==================== Real Debrid
 {'setting_id': 'rd.token', 'setting_type': 'string', 'setting_default': 'empty_setting'},
 {'setting_id': 'rd.enabled', 'setting_type': 'boolean', 'setting_default': 'false'},

--- a/plugin.video.redlight/resources/lib/caches/tmdb_lists.py
+++ b/plugin.video.redlight/resources/lib/caches/tmdb_lists.py
@@ -56,12 +56,20 @@ class TMDbListsCache(BaseCache):
 			return True
 		except: return False
 
+	def get_sort_orders_strict(self):
+		"""Every stored per-list sort order. Raises on a locked database or a malformed row.
+
+		The one-time sort migration reads the store through this, not through the swallowing
+		get_sort_orders() below: an empty dict means "nothing stored" and lets the migration
+		record itself as done, so a read failure that returned {} would look exactly like a
+		clean success and delete every stored preference on the following sync.
+		"""
+		dbcon = self.manual_connect('tmdb_lists_db')
+		cache_data = dbcon.execute('SELECT id, data FROM tmdb_lists WHERE id LIKE %s' % "'sort_order_%'").fetchall()
+		return dict([(int(i[0].replace('sort_order_', '')), i[1]) for i in cache_data])
+
 	def get_sort_orders(self):
-		try:
-			dbcon = self.manual_connect('tmdb_lists_db')
-			cache_data = dbcon.execute('SELECT id, data FROM tmdb_lists WHERE id LIKE %s' % "'sort_order_%'").fetchall()
-			cache_data = dict([(int(i[0].replace('sort_order_', '')), i[1]) for i in cache_data])
-			return cache_data
+		try: return self.get_sort_orders_strict()
 		except: return {}
 
 tmdb_lists_cache = TMDbListsCache()

--- a/plugin.video.redlight/resources/lib/caches/trakt_cache.py
+++ b/plugin.video.redlight/resources/lib/caches/trakt_cache.py
@@ -99,12 +99,21 @@ def get_list_custom_sort(list_id):
 		return eval(cache_data[0])
 	except: return {}
 
+def get_all_lists_custom_sort_strict():
+	"""Every stored per-list custom sort. Raises on a locked database or a corrupt row.
+
+	The one-time sort migration reads the store through this, not through the swallowing
+	get_all_lists_custom_sort() below: an empty dict means "nothing stored" and lets the
+	migration record itself as done, so a read failure that returned {} would look exactly
+	like a clean success and delete every stored preference on the following sync.
+	"""
+	dbcon = connect_database('trakt_db')
+	all_cache_data = dbcon.execute('SELECT data FROM trakt_data WHERE id LIKE %s' % "'trakt_list_custom_sort_%'").fetchall()
+	all_cache_data = (eval(i[0]) for i in all_cache_data)
+	return dict([(i['list_id'], {'sort_by': i['sort_by'], 'sort_how': i['sort_how']}) for i in all_cache_data])
+
 def get_all_lists_custom_sort():
-	try:
-		dbcon = connect_database('trakt_db')
-		all_cache_data = dbcon.execute('SELECT data FROM trakt_data WHERE id LIKE %s' % "'trakt_list_custom_sort_%'").fetchall()
-		all_cache_data = (eval(i[0]) for i in all_cache_data)
-		return dict([(i['list_id'], {'sort_by': i['sort_by'], 'sort_how': i['sort_how']}) for i in all_cache_data])
+	try: return get_all_lists_custom_sort_strict()
 	except: return {}
 
 def valid_trakt_activities(data):

--- a/plugin.video.redlight/resources/lib/indexers/dialogs.py
+++ b/plugin.video.redlight/resources/lib/indexers/dialogs.py
@@ -1427,3 +1427,62 @@ def media_extra_info_choice(params):
 def discover_choice(params):
 	from windows.base_window import open_window
 	open_window(('windows.discover', 'Discover'), 'discover.xml', media_type=params['media_type'])
+
+def sort_default_choice(params):
+	from modules import list_sort
+	media_type = params['media_type']
+	setting_id = 'sort.default.%s' % media_type
+	current = list_sort.parse_spec(get_setting('redlight.%s' % setting_id, ''))
+	heading = 'Default Sort For %s' % ('Movies' if media_type == 'movies' else 'TV Shows')
+	# Not any single adapter's field list: this setting is read by every mediatype-split list at once,
+	# and a field one of those adapters cannot extract would leave that list in raw cache order.
+	spec = _pick_sort_spec(heading, None, current=current, fields=list_sort.default_field_choices())
+	if spec == None: return
+	set_setting(setting_id, list_sort.format_spec(spec))
+	set_setting('%s_name' % setting_id, list_sort.spec_label(spec))
+	kodi_utils.kodi_refresh()
+
+def list_sort_override_choice(params):
+	from modules import list_sort
+	from caches.list_sort_cache import scope_key, set_override, delete_override
+	list_key, media_type, adapter_name = params['list_key'], params.get('media_type'), params['adapter']
+	scope = scope_key(list_key, media_type)
+	# The fallback is the ordering the list has when nothing is stored for it - a Trakt user list's
+	# own declared sort, say - so without it the "current" marker would point at title:asc for every
+	# list the user has never overridden, which is not the order on screen.
+	current = list_sort.resolve(list_key, media_type, params.get('fallback'))
+	spec = _pick_sort_spec('Custom Sort', adapter_name, allow_default=True, current=current)
+	if spec == None: return
+	if spec == 'use_default': success = delete_override(scope)
+	else: success = set_override(scope, list_sort.format_spec(spec))
+	if success: kodi_utils.kodi_refresh()
+	else: kodi_utils.ok_dialog('Custom Sort', 'An Error Occurred')
+
+def _pick_sort_spec(heading, adapter_name, allow_default=False, current=None, fields=None):
+	"""Two stage picker: field, then direction. Returns a spec dict, 'use_default', or None.
+
+	'current' is the spec the list is sorted by right now; the matching entries are marked.
+	'fields' overrides the adapter's own capabilities, for a setting read by several adapters at once.
+	"""
+	from modules import list_sort
+	current = current or {}
+	if fields is None: fields = list_sort.field_choices(adapter_name)
+	choices = []
+	if allow_default: choices.append(('use_default', 'Use Default'))
+	choices.extend([(i, list_sort.FIELD_LABELS.get(i, i)) for i in fields])
+	if not choices: return None
+	field = _sort_select_dialog(choices, '%s: Field' % heading, current.get('field'))
+	if field == None: return None
+	if field == 'use_default': return 'use_default'
+	if field in list_sort.DIRECTIONLESS_FIELDS: return {'field': field, 'direction': 'asc'}
+	direction_choices = [('asc', 'Ascending'), ('desc', 'Descending')]
+	current_direction = current.get('direction') if current.get('field') == field else None
+	direction = _sort_select_dialog(direction_choices, '%s: Direction' % heading, current_direction)
+	if direction == None: return None
+	return {'field': field, 'direction': direction}
+
+def _sort_select_dialog(choices, heading, current_value):
+	current_mark = '   [B][COLOR green][CURRENT][/COLOR][/B]'
+	list_items = [{'line1': '%s%s' % (i[1], current_mark if i[0] == current_value else ''), 'line2': ''} for i in choices]
+	kwargs = {'items': json.dumps(list_items), 'heading': heading, 'narrow_window': 'true'}
+	return kodi_utils.select_dialog([i[0] for i in choices], **kwargs)

--- a/plugin.video.redlight/resources/lib/indexers/navigator.py
+++ b/plugin.video.redlight/resources/lib/indexers/navigator.py
@@ -222,6 +222,15 @@ class Navigator:
 	def _simkl_list_link(self, list_mode, action, category_name):
 		return {'mode': list_mode, 'action': action, 'category_name': category_name}
 
+	def _simkl_sort_cm(self, media_type):
+		"""Simkl's every status list shares one scope per media type (apis/simkl_api.py sorts them all
+		under the 'simkl' list key), so this entry sets the order for all Simkl movie or TV lists.
+
+		The label says so. Plain 'Set Custom Sort' here would read as list-specific and silently
+		reorder the other four statuses."""
+		kind = 'Movie' if media_type == 'movies' else 'TV'
+		return self._sort_cm('simkl', media_type, 'simkl', label='Set Custom Sort (All Simkl %s Lists)' % kind)
+
 	def simkl_lists(self):
 		"""Flat status lists (v1.3.4 layout) — direct links to each Movies/TV list."""
 		self.category_name = 'Simkl Lists'
@@ -237,46 +246,51 @@ class Navigator:
 			(self._simkl_list_link('build_movie_list', 'simkl_dropped', 'Movies Dropped'), 'Movies Dropped'),
 			(self._simkl_list_link('build_tvshow_list', 'simkl_dropped', 'TV Shows Dropped'), 'TV Shows Dropped'),
 		):
-			self._safe_add(url_params, label, 'simkl')
+			media_type = 'movies' if url_params['mode'] == 'build_movie_list' else 'shows'
+			self._safe_add(url_params, label, 'simkl', cm_items=self._simkl_sort_cm(media_type))
 		self._safe_add({'mode': 'navigator.search_history', 'action': 'simkl_lists'}, 'Search My Simkl Lists', 'search')
 		self.end_directory()
 
 	def simkl_watchlists(self):
 		self.category_name = 'Plan to Watch'
-		self._safe_add(self._simkl_list_link('build_movie_list', 'simkl_plantowatch', 'Movies Plan to Watch'), 'Movies', 'simkl')
-		self._safe_add(self._simkl_list_link('build_tvshow_list', 'simkl_plantowatch', 'TV Shows Plan to Watch'), 'TV Shows', 'simkl')
+		self._safe_add(self._simkl_list_link('build_movie_list', 'simkl_plantowatch', 'Movies Plan to Watch'), 'Movies', 'simkl', cm_items=self._simkl_sort_cm('movies'))
+		self._safe_add(self._simkl_list_link('build_tvshow_list', 'simkl_plantowatch', 'TV Shows Plan to Watch'), 'TV Shows', 'simkl', cm_items=self._simkl_sort_cm('shows'))
 		self.end_directory()
 
 	def simkl_completed(self):
 		self.category_name = 'Completed'
-		self._safe_add(self._simkl_list_link('build_movie_list', 'simkl_completed', 'Movies Completed'), 'Movies', 'simkl')
-		self._safe_add(self._simkl_list_link('build_tvshow_list', 'simkl_completed', 'TV Shows Completed'), 'TV Shows', 'simkl')
+		self._safe_add(self._simkl_list_link('build_movie_list', 'simkl_completed', 'Movies Completed'), 'Movies', 'simkl', cm_items=self._simkl_sort_cm('movies'))
+		self._safe_add(self._simkl_list_link('build_tvshow_list', 'simkl_completed', 'TV Shows Completed'), 'TV Shows', 'simkl', cm_items=self._simkl_sort_cm('shows'))
 		self.end_directory()
 
 	def simkl_watching(self):
 		self.category_name = 'Watching'
-		self._safe_add(self._simkl_list_link('build_movie_list', 'simkl_watching', 'Movies Watching'), 'Movies', 'simkl')
-		self._safe_add(self._simkl_list_link('build_tvshow_list', 'simkl_watching', 'TV Shows Watching'), 'TV Shows', 'simkl')
+		self._safe_add(self._simkl_list_link('build_movie_list', 'simkl_watching', 'Movies Watching'), 'Movies', 'simkl', cm_items=self._simkl_sort_cm('movies'))
+		self._safe_add(self._simkl_list_link('build_tvshow_list', 'simkl_watching', 'TV Shows Watching'), 'TV Shows', 'simkl', cm_items=self._simkl_sort_cm('shows'))
 		self.end_directory()
 
 	def simkl_hold(self):
 		self.category_name = 'On Hold'
-		self._safe_add(self._simkl_list_link('build_movie_list', 'simkl_hold', 'Movies On Hold'), 'Movies', 'simkl')
-		self._safe_add(self._simkl_list_link('build_tvshow_list', 'simkl_hold', 'TV Shows On Hold'), 'TV Shows', 'simkl')
+		self._safe_add(self._simkl_list_link('build_movie_list', 'simkl_hold', 'Movies On Hold'), 'Movies', 'simkl', cm_items=self._simkl_sort_cm('movies'))
+		self._safe_add(self._simkl_list_link('build_tvshow_list', 'simkl_hold', 'TV Shows On Hold'), 'TV Shows', 'simkl', cm_items=self._simkl_sort_cm('shows'))
 		self.end_directory()
 
 	def simkl_dropped(self):
 		self.category_name = 'Dropped'
-		self._safe_add(self._simkl_list_link('build_movie_list', 'simkl_dropped', 'Movies Dropped'), 'Movies', 'simkl')
-		self._safe_add(self._simkl_list_link('build_tvshow_list', 'simkl_dropped', 'TV Shows Dropped'), 'TV Shows', 'simkl')
+		self._safe_add(self._simkl_list_link('build_movie_list', 'simkl_dropped', 'Movies Dropped'), 'Movies', 'simkl', cm_items=self._simkl_sort_cm('movies'))
+		self._safe_add(self._simkl_list_link('build_tvshow_list', 'simkl_dropped', 'TV Shows Dropped'), 'TV Shows', 'simkl', cm_items=self._simkl_sort_cm('shows'))
 		self.end_directory()
 
 	def mdblist_lists(self):
 		self.category_name = 'MDBList Lists'
-		self._safe_add({'mode': 'build_movie_list', 'action': 'mdblist_watchlist', 'category_name': 'Movies Watchlist'}, 'Movies Watchlist', 'mdblist')
-		self._safe_add({'mode': 'build_tvshow_list', 'action': 'mdblist_watchlist', 'category_name': 'TV Shows Watchlist'}, 'TV Shows Watchlist', 'mdblist')
-		self._safe_add({'mode': 'build_movie_list', 'action': 'mdblist_collection', 'category_name': 'Movies Library'}, 'Movies Library', 'mdblist')
-		self._safe_add({'mode': 'build_tvshow_list', 'action': 'mdblist_collection', 'category_name': 'TV Shows Library'}, 'TV Shows Library', 'mdblist')
+		self._safe_add({'mode': 'build_movie_list', 'action': 'mdblist_watchlist', 'category_name': 'Movies Watchlist'}, 'Movies Watchlist', 'mdblist',
+					cm_items=self._sort_cm('mdblist.watchlist', 'movies', 'mdblist_watchlist'))
+		self._safe_add({'mode': 'build_tvshow_list', 'action': 'mdblist_watchlist', 'category_name': 'TV Shows Watchlist'}, 'TV Shows Watchlist', 'mdblist',
+					cm_items=self._sort_cm('mdblist.watchlist', 'shows', 'mdblist_watchlist'))
+		self._safe_add({'mode': 'build_movie_list', 'action': 'mdblist_collection', 'category_name': 'Movies Library'}, 'Movies Library', 'mdblist',
+					cm_items=self._sort_cm('mdblist.collection', 'movies', 'mdblist_collection'))
+		self._safe_add({'mode': 'build_tvshow_list', 'action': 'mdblist_collection', 'category_name': 'TV Shows Library'}, 'TV Shows Library', 'mdblist',
+					cm_items=self._sort_cm('mdblist.collection', 'shows', 'mdblist_collection'))
 		self._safe_add({'mode': 'build_tvshow_list', 'action': 'mdblist_droplist', 'category_name': 'Dropped TV Shows'}, 'Dropped TV Shows', 'mdblist')
 		self._safe_add({'mode': 'mdblist.get_mdbl_lists', 'name': 'My Lists'}, 'My Lists', 'mdblist')
 		self._safe_add({'mode': 'mdblist.get_mdbl_liked_lists', 'name': 'Movies Liked Lists', 'media_type': 'movie'}, 'Movies Liked Lists', 'mdblist')
@@ -287,8 +301,10 @@ class Navigator:
 
 	def trakt_collections(self):
 		self.category_name = 'Collection'
-		self.add({'mode': 'build_movie_list', 'action': 'trakt_collection', 'category_name': 'Movies Collection'}, 'Movies Collection', 'trakt')
-		self.add({'mode': 'build_tvshow_list', 'action': 'trakt_collection', 'category_name': 'TV Shows Collection'}, 'TV Shows Collection', 'trakt')
+		self.add({'mode': 'build_movie_list', 'action': 'trakt_collection', 'category_name': 'Movies Collection'}, 'Movies Collection', 'trakt',
+					cm_items=self._sort_cm('trakt.collection', 'movies', 'trakt_sync'))
+		self.add({'mode': 'build_tvshow_list', 'action': 'trakt_collection', 'category_name': 'TV Shows Collection'}, 'TV Shows Collection', 'trakt',
+					cm_items=self._sort_cm('trakt.collection', 'shows', 'trakt_sync'))
 		self.add({'mode': 'build_movie_list', 'action': 'trakt_collection_lists', 'new_page': 'recent', 'category_name': 'Recently Added Movies'}, 'Recently Added Movies', 'trakt')
 		self.add({'mode': 'build_tvshow_list', 'action': 'trakt_collection_lists', 'new_page': 'recent', 'category_name': 'Recently Added TV Shows'},
 					'Recently Added TV Shows', 'trakt')
@@ -298,8 +314,10 @@ class Navigator:
 
 	def trakt_watchlists(self):
 		self.category_name = 'Watchlist'
-		self.add({'mode': 'build_movie_list', 'action': 'trakt_watchlist', 'category_name': 'Movies Watchlist'}, 'Movies Watchlist', 'trakt')
-		self.add({'mode': 'build_tvshow_list', 'action': 'trakt_watchlist', 'category_name': 'TV Shows Watchlist'}, 'TV Shows Watchlist', 'trakt')
+		self.add({'mode': 'build_movie_list', 'action': 'trakt_watchlist', 'category_name': 'Movies Watchlist'}, 'Movies Watchlist', 'trakt',
+					cm_items=self._sort_cm('trakt.watchlist', 'movies', 'trakt_sync'))
+		self.add({'mode': 'build_tvshow_list', 'action': 'trakt_watchlist', 'category_name': 'TV Shows Watchlist'}, 'TV Shows Watchlist', 'trakt',
+					cm_items=self._sort_cm('trakt.watchlist', 'shows', 'trakt_sync'))
 		self.add({'mode': 'build_movie_list', 'action': 'trakt_watchlist_lists', 'new_page': 'recent', 'category_name': 'Recently Added Movies'}, 'Recently Added Movies', 'trakt')
 		self.add({'mode': 'build_tvshow_list', 'action': 'trakt_watchlist_lists', 'new_page': 'recent', 'category_name': 'Recently Added TV Shows'},
 					'Recently Added TV Shows', 'trakt')
@@ -749,6 +767,18 @@ class Navigator:
 		func = function()
 		for item in func: self.add(item, item['name'], item['iconImage'])
 		self.end_directory()
+
+	def _sort_cm(self, list_key, media_type, adapter, label='Set Custom Sort'):
+		"""Context menu entry that overrides the sort order of one mediatype split list.
+
+		list_key/adapter must match the list_sort.sort_source() call that builds the list, and a new
+		list is returned on every call because add() appends to whatever it is given.
+
+		Pass label where one scope backs several visible lists, so the entry does not imply it only
+		affects the list it was opened from - see _simkl_sort_cm.
+		"""
+		return [('[B]%s[/B]' % label, self.run_plugin % self.build_url(
+			{'mode': 'list_sort_override_choice', 'list_key': list_key, 'media_type': media_type, 'adapter': adapter}))]
 
 	def _safe_add(self, url_params, list_name, iconImage='folder', original_image=False, cm_items=[]):
 		try: self.add(url_params, list_name, iconImage, original_image, cm_items)

--- a/plugin.video.redlight/resources/lib/indexers/personal_lists.py
+++ b/plugin.video.redlight/resources/lib/indexers/personal_lists.py
@@ -172,6 +172,7 @@ def delete_personal_list(params):
 	if not kodi_utils.confirm_dialog(heading='Personal Lists', text='Delete [B]%s[/B] Personal List?' % list_name): return
 	if personal_lists_cache.delete_list(list_name, author):
 		for image_type, custom_image in (('poster', poster), ('fanart', fanart)): delete_current_image(image_type, list_name, author, custom_image)
+		_delete_sort_override(list_name, author)
 		return kodi_utils.kodi_refresh()
 	kodi_utils.notification('Error Deleting List', 3000)
 
@@ -182,16 +183,16 @@ def delete_personal_list_contents(params):
 	kodi_utils.notification('Error Deleting List Contents', 3000)
 
 def get_personal_list(params):
-	list_name, author, sort_order, seen, update_seen = params['list_name'], params['author'], params['sort_order'], params.get('seen', True), params.get('update_seen', True)
+	list_name, author, seen, update_seen = params['list_name'], params['author'], params.get('seen', True), params.get('update_seen', True)
 	contents = personal_lists_cache.get_list(list_name, author, update_seen=update_seen, seen=seen)
-	try:
-		if sort_order == 'None': pass
-		elif sort_order in ('5', 'shuffle'): shuffle(contents)
-		elif sort_order in ('', '0'): contents = sort_for_article(contents, 'title', settings.ignore_articles())
-		elif sort_order in ('1', '2'): contents.sort(key=lambda k: int(k['date_added']), reverse=sort_order != '1')
-		else: contents.sort(key=lambda k: (k['release_date'] is None, k['release_date']), reverse=sort_order != '3')
-	except: pass
-	return contents
+	from modules import list_sort
+	# No fallback, unlike the Trakt and TMDb call sites: those exist to preserve a provider's own
+	# declared ordering for a list nobody has overridden yet. A personal list has no such ordering -
+	# migrate_legacy_stores() already turned every list's old sort_order column into an override row,
+	# so one with no override now is one nobody has ever chosen a sort for, and the engine's own
+	# default (title:asc) is the right answer. A 'default:asc' fallback would read as "Provider
+	# Default" for a provider that does not exist.
+	return list_sort.sort_source(contents, 'personal:%s|%s' % (list_name, author), None, 'personal')
 
 def make_new_personal_list(params):
 	is_retry, external_creation = params.get('is_retry', False), params.get('external_creation', 'false') == 'true'
@@ -213,12 +214,16 @@ def make_new_personal_list(params):
 		params['is_retry'] = True
 		return make_new_personal_list(params)
 	description = personal_list_description()
-	sort_order = personal_sort_order()
-	if sort_order == None: return None, None
-	success = personal_lists_cache.make_list(list_name, author, sort_order, description)
+	spec = personal_sort_order()
+	if spec == None: return None, None
+	# The sort_order column is kept in step for anything that still displays it, but the list is
+	# sorted from the override store - writing only the column, as this did before, meant every list
+	# created after the upgrade ignored the sort order chosen right here and came back title first.
+	success = personal_lists_cache.make_list(list_name, author, _legacy_sort_code(spec), description)
 	if not success:
 		kodi_utils.notification('Error Creating List', 3000)
 		return None, None
+	_set_sort_override(list_name, author, spec)
 	if chosen_list:
 		new_contents = process_trakt_list(chosen_list)
 		result = personal_lists_cache.add_many_list_items(list_name, author, new_contents)
@@ -226,13 +231,13 @@ def make_new_personal_list(params):
 	return list_name, author
 
 def adjust_personal_list_properties(params):
-	sort_order_dict = {'0': 'Title', '1': 'Date Added (asc)', '2': 'Date Added (desc)', '3': 'Release Date (asc)', '4': 'Release Date (desc)', '5': 'Shuffle'}
+	from modules import list_sort
 	list_name, sort_order, author = params.get('list_name', ''), params.get('sort_order', ''), params.get('author', '')
 	seen, description = params.get('seen', ''), params.get('description', '')
 	poster, fanart = params.get('poster', ''), params.get('fanart', '')
 	choices = [('Change Name', 'Currently [B]%s[/B]' % (list_name), 'list_name'),
 				('Change Author', 'Currently [B]%s[/B]' % (author), 'author'),
-				('Change Sort Order', 'Currently [B]%s[/B]' % sort_order_dict.get(sort_order, 'None'), 'sort_order'),
+				('Change Sort Order', 'Currently [B]%s[/B]' % list_sort.spec_label(_current_sort_spec(list_name, author)), 'sort_order'),
 				('Change List Description', 'Currently [B]%s[/B]' % (description), 'description'),
 				('Make Custom Poster', '', 'make_poster'),
 				('Make Custom Fanart', '', 'make_fanart')]
@@ -254,16 +259,20 @@ def adjust_personal_list_properties(params):
 		new_name = personal_list_name(list_name)
 		if new_name == None: return adjust_personal_list_properties(params)
 		personal_lists_cache.update_single_detail('name', new_name, list_name, author)
+		_move_sort_override(list_name, author, new_name, author)
 		params.update({'list_name': new_name, 'refresh': 'true'})
 	if action == 'author':
 		new_author = personal_list_author(author)
 		personal_lists_cache.update_single_detail('author', new_author, list_name, author)
+		_move_sort_override(list_name, author, list_name, new_author)
 		params.update({'author': new_author, 'refresh': 'true'})
 	elif action == 'sort_order':
-		new_sort_order = personal_sort_order()
-		if new_sort_order == None: return adjust_personal_list_properties(params)
-		personal_lists_cache.update_single_detail('sort_order', new_sort_order, list_name, author)
-		params.update({'sort_order': new_sort_order, 'refresh': 'true'})
+		spec = personal_sort_order(current=_current_sort_spec(list_name, author))
+		if spec == None: return adjust_personal_list_properties(params)
+		if _set_sort_override(list_name, author, spec):
+			new_sort_order = _legacy_sort_code(spec)
+			personal_lists_cache.update_single_detail('sort_order', new_sort_order, list_name, author)
+			params.update({'sort_order': new_sort_order, 'refresh': 'true'})
 	elif action == 'description':
 		new_description = personal_list_description()
 		personal_lists_cache.update_single_detail('description', new_description, list_name, author)
@@ -341,13 +350,60 @@ def personal_list_author(author=''):
 	new_author = unquote(new_author)
 	return new_author
 
-def personal_sort_order():
-	choices = [('Title (asc)', '0'), ('Date Added (asc)', '1'), ('Date Added (desc)', '2'), ('Release Date (asc)', '3'), ('Release Date (desc)', '4'), ('Shuffle', '5')]
-	list_items = [{'line1': item[0]} for item in choices]
-	kwargs = {'items': json.dumps(list_items), 'heading': 'List Sort Order', 'narrow_window': 'true'}
-	sort_order = kodi_utils.select_dialog([i[1] for i in choices], **kwargs)
-	if sort_order == None: return None
-	return sort_order
+def personal_sort_order(current=None):
+	"""The shared two stage sort picker. Returns a spec dict or None.
+
+	No "Use Default" entry: a personal list is mixed media, so it has no mediatype default to fall
+	back to. The adapter's own 'default' field (Provider Default) is the equivalent choice.
+	"""
+	from indexers.dialogs import _pick_sort_spec
+	return _pick_sort_spec('List Sort Order', 'personal', current=current)
+
+def _sort_scope(list_name, author):
+	from caches.list_sort_cache import scope_key
+	return scope_key('personal:%s|%s' % (list_name, author))
+
+def _current_sort_spec(list_name, author):
+	"""What get_personal_list will actually sort by. It passes no fallback, so an absent override
+	means the engine's own default rather than the list's stored order."""
+	from modules import list_sort
+	return list_sort.resolve('personal:%s|%s' % (list_name, author))
+
+def _legacy_sort_code(spec):
+	"""The legacy sort_order column value for a spec, '0' (title) when the spec has no equivalent.
+
+	Nothing reads the column for ordering any more; it is written only so exports and the row in
+	personal_lists.db keep describing the same list the override store describes.
+	"""
+	from modules import list_sort
+	spec_string = list_sort.format_spec(spec)
+	for code, legacy_spec in list_sort.LEGACY_PERSONAL_CODES.items():
+		if legacy_spec == spec_string and code != '': return code
+	return '0'
+
+def _set_sort_override(list_name, author, spec):
+	from caches.list_sort_cache import set_override
+	from modules import list_sort
+	if set_override(_sort_scope(list_name, author), list_sort.format_spec(spec)): return True
+	kodi_utils.notification('Error Setting Sort Order', 3000)
+	return False
+
+def _move_sort_override(old_name, old_author, new_name, new_author):
+	"""A personal list's override scope is keyed by name and author, so a rename has to carry it."""
+	from caches.list_sort_cache import get_override, set_override, delete_override
+	old_scope, new_scope = _sort_scope(old_name, old_author), _sort_scope(new_name, new_author)
+	if old_scope == new_scope: return
+	spec_string = get_override(old_scope)
+	if not spec_string: return
+	if set_override(new_scope, spec_string): delete_override(old_scope)
+
+def _delete_sort_override(list_name, author):
+	"""Same defect class as the rename orphan above: the override scope is keyed by name and author,
+	not by any id the deleted row still owns, so a deleted list's row would otherwise sit there ready
+	to be silently inherited by a future list created with the same name and author. Best effort - a
+	failed delete leaves a harmless orphaned row, since the list it described is already gone."""
+	from caches.list_sort_cache import delete_override
+	delete_override(_sort_scope(list_name, author))
 
 def personal_list_description():
 	description = kodi_utils.kodi_dialog().input('Optional Description for the New List') or ' '
@@ -369,6 +425,7 @@ def import_trakt_list(params):
 	if result == 'Success':
 		if kodi_utils.confirm_dialog(heading='Personal Lists', text='Rename List to Match Trakt List Name?', ok_label='Yes', cancel_label='No'):
 			personal_lists_cache.update_single_detail('name', trakt_list_name, list_name, author)
+			_move_sort_override(list_name, author, trakt_list_name, author)
 	kodi_utils.notification(result, 3000)
 
 def process_trakt_list(chosen_list):
@@ -382,7 +439,8 @@ def process_trakt_list(chosen_list):
 		trakt_media_type = chosen_list.get('media_type')
 		result = trakt_fetch_collection_watchlist(trakt_list_type, trakt_media_type)
 		try:
-			result = settings.sort_trakt_sync_list(result, trakt_list_type)
+			from modules import list_sort
+			result = list_sort.sort_source(result, 'trakt.%s' % trakt_list_type, trakt_media_type, 'trakt_sync')
 		except: pass
 	else:
 		result = get_trakt_list_contents(trakt_list_type, chosen_list.get('user'), chosen_list.get('slug'), trakt_list_type == 'my_lists')
@@ -465,6 +523,10 @@ class ExternalImport:
 		self.results.sort(key=lambda k: k['order'])
 		success = personal_lists_cache.make_list(self.list_name, self.author, '1', self.description, seen='true' if self.action == 'import_view' else 'false')
 		if not success: return kodi_utils.notification('Error Creating [B]%s[/B]' % self.list_name, 3000)
+		# Legacy code '1' is date added ascending, which for an import is the order of the imported
+		# file. The column no longer orders anything, so the same choice has to be stored as an
+		# override or the imported list comes back alphabetised.
+		_set_sort_override(self.list_name, self.author, {'field': 'date_added', 'direction': 'asc'})
 		items_added = personal_lists_cache.add_many_list_items(self.list_name, self.author, self.results)
 		if items_added == 'Success':
 			if self.poster: self.poster = personal_image_maker(self.list_name, self.author, 'poster', '1', 'false', '', True if self.poster == 'random' else False, show_busy=False)

--- a/plugin.video.redlight/resources/lib/indexers/random_lists.py
+++ b/plugin.video.redlight/resources/lib/indexers/random_lists.py
@@ -283,7 +283,7 @@ class RandomLists():
 			list_id = random_list['ids']['trakt']
 			list_name = random_list['name']
 			with_auth = list_type == 'my_lists'
-			result = get_trakt_list_contents(list_type, user, slug, with_auth, list_id, 'skip')
+			result = get_trakt_list_contents(list_type, user, slug, with_auth, list_id, skip_sort=True)
 			random.shuffle(result)
 			if paginate(self.is_external): data = random.sample(result, min(len(result), page_limit(self.is_external)))
 			else: data = random.sample(result, len(result))
@@ -359,7 +359,7 @@ class RandomLists():
 		if not random_list:
 			user, slug, list_id = self.params_get('user'), self.params_get('slug'), self.params_get('list_id')
 			with_auth = list_type == 'my_lists'
-			result = get_trakt_list_contents(list_type, user, slug, with_auth, list_id, 'skip')
+			result = get_trakt_list_contents(list_type, user, slug, with_auth, list_id, skip_sort=True)
 			random.shuffle(result)
 			if paginate(self.is_external): result = random.sample(result, min(len(result), page_limit(self.is_external)))
 			result = [dict(i, **{'order': c}) for c, i in enumerate(result)]

--- a/plugin.video.redlight/resources/lib/indexers/tmdb_lists.py
+++ b/plugin.video.redlight/resources/lib/indexers/tmdb_lists.py
@@ -11,7 +11,7 @@ from caches.tmdb_lists import tmdb_lists_cache
 from indexers.movies import Movies
 from indexers.tvshows import TVShows
 from modules.utils import paginate_list, sort_for_article, gen_md5, jsondate_to_datetime as js2date
-from modules.settings import paginate, page_limit, lists_sort_order, widget_hide_next_page, ignore_articles, jump_to_enabled, tmdblists_sort_order
+from modules.settings import paginate, page_limit, widget_hide_next_page, ignore_articles, jump_to_enabled
 from modules import kodi_utils
 # logger = kodi_utils.logger
 
@@ -154,13 +154,17 @@ def build_tmdb_list(params):
 		kodi_utils.set_view_mode('view.%s' % content, content, is_external)
 
 def adjust_tmdb_list_properties(params):
-	sort_order_dict = {'0': 'Title', '1': 'Release Date (asc)', '2': 'Release Date (desc)', '3': 'Shuffle'}
-	list_id, sort_order = params.get('list_id'), params.get('sort_order', '')
-	original_list_name, original_sort_order = params.get('original_list_name', ''), params.get('original_sort_order', '')
+	from modules import list_sort
+	list_id = params.get('list_id')
+	original_list_name = params.get('original_list_name', '')
 	custom_poster, custom_fanart = params.get('custom_poster', ''), params.get('custom_fanart', '')
-	current_name, current_sort_order = params.get('list_name', '') or original_list_name, sort_order or original_sort_order
+	current_name = params.get('list_name', '') or original_list_name
+	# The sort_order carried in the URL is the legacy column, which nothing reads any more. The label
+	# and the picker both go through the override store so the row states what the list actually does.
+	# 'default:asc' is get_tmdb_list's fallback: no override means the list is served in TMDb order.
+	current_sort = list_sort.resolve('tmdb:%s' % list_id, None, 'default:asc')
 	choices = [('Change Name', 'Currently [B]%s[/B]' % (current_name), 'list_name'),
-				('Change Sort Order', 'Currently [B]%s[/B]' % sort_order_dict.get(current_sort_order, 'None'), 'sort_order'),
+				('Change Sort Order', 'Currently [B]%s[/B]' % list_sort.spec_label(current_sort), 'sort_order'),
 				('Make Custom Poster', '', 'make_poster'),
 				('Make Custom Fanart', '', 'make_fanart')]
 	if custom_poster: choices.append(('Delete Custom Poster', '', 'delete_poster'))
@@ -185,11 +189,15 @@ def adjust_tmdb_list_properties(params):
 		current_name = list_name
 		params.update({'list_name': current_name, 'refresh_cache': 'true'})
 	elif action == 'sort_order':
-		sort_order = sort_order_tmdb_list()
-		if sort_order == None: return adjust_tmdb_list_properties(params)
-		if set_sort_order(list_id, sort_order):
-			current_sort_order = sort_order
-			params.update({'sort_order': current_sort_order, 'refresh': 'true'})
+		from caches.list_sort_cache import set_override
+		from indexers.dialogs import _pick_sort_spec
+		# No "Use Default" entry: a TMDb list is mixed media, so it has no mediatype default to fall
+		# back to. The equivalent choice is the adapter's own 'default' field (Provider Default),
+		# which stores 'default:asc' and hands back TMDb's ordering untouched.
+		spec = _pick_sort_spec('List Sort Order', 'tmdb', current=current_sort)
+		if spec == None: return adjust_tmdb_list_properties(params)
+		if set_override('tmdb:%s' % list_id, list_sort.format_spec(spec)): params.update({'refresh': 'true'})
+		else: kodi_utils.notification('Error Setting Sort Order', 3000)
 	elif action == 'make_poster':
 		new_poster = tmdb_image_maker(current_name, list_id, 'poster', custom_poster, shuffle_sort_order)
 		if new_poster is None: return adjust_tmdb_list_properties(params)
@@ -285,14 +293,6 @@ def rename_tmdb_list(current_name, list_id):
 	if list_name == None: return None
 	tmdb_list_api.rename_list(list_id, list_name)
 	return list_name
-
-def sort_order_tmdb_list():
-	choices = [('Title (asc)', '0'), ('Release Date (asc)', '1'), ('Release Date (desc)', '2'), ('Shuffle', '3'), ('Default From TMDb (None)', 'None')]
-	list_items = [{'line1': item[0]} for item in choices]
-	kwargs = {'items': json.dumps(list_items), 'heading': 'List Sort Order', 'narrow_window': 'true'}
-	sort_order = kodi_utils.select_dialog([i[1] for i in choices], **kwargs)
-	if sort_order == None: return None
-	return sort_order
 
 def check_item_status(list_id, media_type, media_id):
 	media_type = _tmdb_media_type(media_type)
@@ -419,22 +419,19 @@ def get_all_tmdb_lists(sort_order=None):
 	return contents
 
 def get_tmdb_list(params):
-	list_id, media_type, sort_order = params['list_id'], params.get('media_type'), params.get('sort_order', None)
+	list_id, media_type = params['list_id'], params.get('media_type')
 	if list_id in ('watchlist', 'favorites', 'recommendations'):
 		contents = [dict(i, **{'media_type': media_type}) for i in tmdb_list_api.get_watchfavrecs_list_details(list_id, media_type)]
-		sort_order = tmdblists_sort_order(list_id)
 	else:
 		contents = tmdb_list_api.get_list_details(list_id)
 	contents = [dict(i, **{'title': i.get('title') or i.get('name'), 'release_date': i.get('release_date') or i.get('first_air_date')}) for i in contents]
-	if sort_order:
-		try:
-			if sort_order in ('4', 'None', '', 'original_order'): contents.sort(key=lambda k: (k['original_order'] is None, k['original_order']))
-			elif sort_order in ('3', 'shuffle'): shuffle(contents)
-			elif sort_order in ('1', '2'): contents.sort(key=lambda k: (k['release_date'] is None, k['release_date']), reverse=sort_order != '1')
-			elif sort_order in ('', '0', 'None'): contents = sort_for_article(contents, 'title', ignore_articles())
-			else: pass
-		except: pass
-	return contents
+	from modules import list_sort
+	# No override means the list was never sorted client-side: the old getters fell back to code 4
+	# (original_order) for watchlist/favorites and to the stored 'None' for a user list. DEFAULT_SPEC
+	# would reorder every one of them to title on upgrade, with no legacy row left to migrate.
+	# 'recommendations' is included: it was never client-sorted, and with no override row the
+	# fallback hands the payload straight back, so it needs no early return of its own.
+	return list_sort.sort_source(contents, 'tmdb:%s' % list_id, None, 'tmdb', fallback='default:asc')
 
 def cache_delete_all_tmdb(params=None):
 	tmdb_lists_cache.clear_all()
@@ -473,8 +470,8 @@ def process_trakt_list(chosen_list):
 		trakt_media_type = chosen_list.get('media_type')
 		result = trakt_fetch_collection_watchlist(trakt_list_type, trakt_media_type)
 		try:
-			from modules.settings import sort_trakt_sync_list
-			result = sort_trakt_sync_list(result, trakt_list_type)
+			from modules import list_sort
+			result = list_sort.sort_source(result, 'trakt.%s' % trakt_list_type, trakt_media_type, 'trakt_sync')
 		except: pass
 	else:
 		result = get_trakt_list_contents(trakt_list_type, chosen_list.get('user'), chosen_list.get('slug'), trakt_list_type == 'my_lists')
@@ -502,11 +499,6 @@ def process_add_to_list(list_id, new_contents):
 	except: pass
 	kodi_utils.hide_busy_dialog()
 	return success
-
-def set_sort_order(list_id, sort_order):
-	if tmdb_lists_cache.set_sort_order(list_id, sort_order): return True
-	kodi_utils.notification('Error Setting Sort Order', 3000)
-	return False
 
 def get_sort_orders():
 	return tmdb_lists_cache.get_sort_orders()

--- a/plugin.video.redlight/resources/lib/indexers/trakt_lists.py
+++ b/plugin.video.redlight/resources/lib/indexers/trakt_lists.py
@@ -5,7 +5,6 @@ import json
 from random import shuffle
 from threading import Thread
 from apis.trakt_api import trakt_get_lists, trakt_search_lists, get_trakt_list_contents, trakt_lists_with_media
-from caches.trakt_cache import get_all_lists_custom_sort, set_list_custom_sort, delete_list_custom_sort
 from indexers.movies import Movies
 from indexers.tvshows import TVShows
 from indexers.seasons import single_seasons
@@ -80,16 +79,16 @@ def search_trakt_my_lists(params):
 				cm_append = cm.append
 				list_name, list_id, user, slug, item_count = item['name'], item['ids']['trakt'], item['user']['ids']['slug'], item['ids']['slug'], item['item_count']
 				if user in (None, 'None'): continue
-				if str(list_id) in all_custom_sorts:
-					custom_sorts = all_custom_sorts[str(list_id)]
-					sort_by, sort_how = custom_sorts['sort_by'], custom_sorts['sort_how']
-				else: sort_by, sort_how = item['sort_by'], item['sort_how']
+				# Trakt's own declared ordering for the list. The legacy per-list sort store is
+				# write-never now, and reading it here made "Use Default" in the new picker fall back
+				# to the user's pre-upgrade legacy choice instead of to Trakt's declared order.
+				sort_by, sort_how = item['sort_by'], item['sort_how']
 				custom_poster = get_custom_image(list_name, list_type, user, 'poster', all_posters)
 				poster = custom_poster or trakt_icon
 				custom_fanart = get_custom_image(list_name, list_type, user, 'fanart', all_fanart)
 				background = custom_fanart or fanart
 				url_params = {'mode': 'trakt.list.build_trakt_list', 'user': user, 'slug': slug, 'list_type': list_type, 'list_id': list_id,
-					'list_name': list_name, 'iconImage': 'trakt', 'name': list_name, 'sort_by': sort_by, 'sort_how': sort_how}
+					'list_name': list_name, 'iconImage': 'trakt', 'name': list_name}
 				url = kodi_utils.build_folder_url(url_params)
 				display = '%s [I](x%s)[/I]' % (list_name, str(item_count))
 				cm_append(('[B]Make New List[/B]', 'RunPlugin(%s)' % build_url({'mode': 'trakt.make_new_trakt_list'})))
@@ -112,7 +111,6 @@ def search_trakt_my_lists(params):
 	profile_path = kodi_utils.addon_profile()
 	all_posters = kodi_utils.list_dirs(os.path.join(profile_path, 'images', 'trakt_%s_poster' % list_type))[1]
 	all_fanart = kodi_utils.list_dirs(os.path.join(profile_path, 'images', 'trakt_%s_fanart' % list_type))[1]
-	all_custom_sorts = get_all_lists_custom_sort()
 	search_title = params.get('key_id') or params.get('query') or ''
 	query = search_title.strip().lower()
 	try:
@@ -143,10 +141,8 @@ def get_trakt_lists(params):
 				cm_append = cm.append
 				list_name, list_id, user, slug, item_count = item['name'], item['ids']['trakt'], item['user']['ids']['slug'], item['ids']['slug'], item['item_count']
 				if user in (None, 'None'): continue
-				if str(list_id) in all_custom_sorts:
-					custom_sorts = all_custom_sorts[str(list_id)]
-					sort_by, sort_how = custom_sorts['sort_by'], custom_sorts['sort_how']
-				else: sort_by, sort_how =  item['sort_by'], item['sort_how']
+				# See search_trakt_my_lists: Trakt's declared order, not the legacy store.
+				sort_by, sort_how = item['sort_by'], item['sort_how']
 				custom_poster = get_custom_image(list_name, list_type, user, 'poster', all_posters)
 				if custom_poster: poster = custom_poster
 				else: poster = trakt_icon
@@ -154,12 +150,15 @@ def get_trakt_lists(params):
 				if custom_fanart: background = custom_fanart
 				else: background = fanart
 				# Parent shuffle (list-of-lists order) is separate from content randomisation.
-				# Content URLs must use random.build_trakt_lists_contents + random=true (sort_by=random),
-				# matching working shortcut-folder entries — not trakt.list.build_trakt_list + shuffle.
+				# When the contents are to be randomised the URL must name the random builder itself -
+				# random.build_trakt_lists_contents with random=true - and not trakt.list.build_trakt_list,
+				# which has no shuffle of its own. The URL carries no sort_by/sort_how: folder URLs no
+				# longer encode an ordering (build_trakt_list resolves it from the stored override and the
+				# payload headers), and the random builder shuffles regardless.
 				random_contents = random or shuffle_lists
 				mode = 'random.build_trakt_lists_contents' if random_contents else 'trakt.list.build_trakt_list'
 				url_params = {'mode': mode, 'user': user, 'slug': slug, 'list_type': list_type, 'list_id': list_id, 'list_name': list_name, 'iconImage': 'trakt',
-				'name': list_name, 'sort_by': 'random' if random_contents else sort_by, 'sort_how': sort_how}
+				'name': list_name}
 				if random_contents: url_params['random'] = 'true'
 				url = kodi_utils.build_folder_url(url_params)
 				if list_type == 'liked_lists':
@@ -208,7 +207,6 @@ def get_trakt_lists(params):
 		all_fanart = kodi_utils.list_dirs(os.path.join(profile_path, 'images', 'trakt_%s_fanart' % list_type))[1]
 		order_prop = 'redlight.trakt.%s.lists.order' % list_type
 		data = trakt_get_lists(list_type) or []
-		all_custom_sorts = get_all_lists_custom_sort()
 		if list_type == 'liked_lists': data = [i['list'] for i in data if isinstance(i, dict) and 'list' in i]
 		if data:
 			if shuffle_lists:
@@ -248,12 +246,11 @@ def get_trakt_user_lists(params):
 				if not slug: continue
 				if item['type'] == 'official': user = 'Trakt Official'
 				if not user: continue
-				sort_by, sort_how =  item['sort_by'], item['sort_how']
 				display = '%s | [I]%s (x%s)[/I]' % (list_name, user, str(item_count))
 				# Parent folder URLs drop random= (build_folder_url skip); shuffle= survives — same pattern as My Lists.
 				mode = 'random.build_trakt_lists_contents' if random_contents else 'trakt.list.build_trakt_list'
 				url_params = {'mode': mode, 'user': user, 'slug': slug, 'list_id': list_id, 'list_type': 'user_lists', 'list_name': list_name, 'iconImage': 'trakt',
-								'name': list_name, 'sort_by': 'random' if random_contents else sort_by, 'sort_how': sort_how}
+								'name': list_name}
 				if random_contents: url_params['random'] = 'true'
 				url = kodi_utils.build_folder_url(url_params)
 				listitem = make_listitem()
@@ -359,9 +356,12 @@ def build_trakt_list(params):
 		if use_result: result = params.get('result', [])
 		else:
 			user, slug, list_id, list_type = params.get('user'), params.get('slug'), params.get('list_id'), params.get('list_type')
-			sort_by, sort_how = params.get('sort_by'), params.get('sort_how')
 			with_auth = list_type == 'my_lists'
-			result = get_trakt_list_contents(list_type, user, slug, with_auth, list_id, sort_by, sort_how)
+			# No sort_by/sort_how: the list resolves its own override and falls back to the ordering
+			# Trakt declares in the payload headers. Passing one here would take the custom-sort branch,
+			# and trakt_image_maker - which cannot pass one - would read a differently shaped cache row
+			# back out of the very same key.
+			result = get_trakt_list_contents(list_type, user, slug, with_auth, list_id)
 			if params.get('shuffle', 'false') == 'true':
 				shuffle(result)
 				for c, i in enumerate(result):
@@ -386,8 +386,8 @@ def build_trakt_list(params):
 		[i.join() for i in threads]
 		item_list.sort(key=lambda k: k[1])
 		if use_result: return content, [i[0] for i in item_list]
-		new_params = {'mode': 'trakt.list.build_trakt_list', 'list_type': list_type, 'list_name': list_name, 'user': user, 'slug': slug, 'paginate_start': paginate_start,
-						'sort_by': sort_by, 'sort_how': sort_how}
+		new_params = {'mode': 'trakt.list.build_trakt_list', 'list_type': list_type, 'list_name': list_name, 'user': user, 'slug': slug,
+						'paginate_start': paginate_start}
 		kodi_utils.add_items(handle, [i[0] for i in item_list])
 		if total_pages > 2 and jump_to_enabled() and not is_external:
 				kodi_utils.add_dir(handle, {'mode': 'navigate_to_page_choice', 'current_page': page_no, 'total_pages': total_pages, 'url_params': json.dumps(new_params)},
@@ -417,13 +417,14 @@ def make_custom_artwork(params):
 	kodi_utils.kodi_refresh()
 
 def trakt_image_maker(list_name, list_type, list_id, image_type, user, slug, custom_image, shuffle_sort_order):
-	from caches.trakt_cache import get_list_custom_sort
 	from modules import metadata
 	from modules.utils import make_image
 	kodi_utils.show_busy_dialog()
-	sort_info = get_list_custom_sort(list_id)
-	sort_by, sort_how = sort_info['sort_by'], sort_info['sort_how']
-	content = get_trakt_list_contents(list_type, user, slug, True, list_id, sort_by, sort_how)
+	# The artwork must be built from the first four items the user sees. get_trakt_list_contents
+	# resolves the list's sort override itself and falls back to the ordering Trakt declares for the
+	# list, so the legacy per-list sort store - which nothing reads any more, and which raised a
+	# KeyError here for any list that had no row - is no longer consulted.
+	content = get_trakt_list_contents(list_type, user, slug, True, list_id)
 	if shuffle_sort_order: shuffle(content)
 	images = []
 	api_key, mpaa, current_time, current_timestamp = tmdb_api_key(), mpaa_region(), get_datetime(), get_current_timestamp()
@@ -451,32 +452,13 @@ def delete_current_image(params):
 	else: kodi_utils.notification('Error Deleting Image')
 
 def set_list_custom_sort(params):
-	list_id, current_by, current_how = params['list_id'], params['sort_by'], params['sort_how']
-	choices = [('default', 'Default From Trakt%s'), ('rank', 'Rank%s'), ('added', 'Date Added%s'), ('title', 'Title%s'), ('released', 'Date Released%s'), ('runtime', 'Runtime%s'),
-	('popularity', 'Popularity%s'), ('percentage', 'Percentage%s'), ('votes', 'Votes%s'), ('random', 'Random%s')]
-	choices = [(i[0], i[1] % ('   [B][COLOR green][CURRENT][/COLOR][/B]' if i[0] == current_by else '')) for i in choices]
-	list_items = [{'line1': item[1], 'line2': ''} for item in choices]
-	kwargs = {'items': json.dumps(list_items), 'heading': 'Trakt List Custom Sort By', 'narrow_window': 'true'}
-	sort_by = kodi_utils.select_dialog([i[0] for i in choices], **kwargs)
-	if sort_by == None: return
-	if sort_by == 'default':
-		from caches.trakt_cache import delete_list_custom_sort
-		success = delete_list_custom_sort(list_id)
-		if success:
-			kodi_utils.ok_dialog('Trakt List Custom Sort', 'Success')
-			kodi_utils.kodi_refresh()
-		else: kodi_utils.ok_dialog('Trakt List Custom Sort', 'An Error Occured')
-		return
-	else:
-		choices = [('asc', 'Ascending%s'), ('desc', 'Descending%s')]
-		choices = [(i[0], i[1] % ('   [B][COLOR green][CURRENT][/COLOR][/B]' if i[0] == current_how else '')) for i in choices]
-		list_items = [{'line1': item[1], 'line2': ''} for item in choices]
-		kwargs = {'items': json.dumps(list_items), 'heading': 'Trakt List Custom Sort How', 'narrow_window': 'true'}
-		sort_how = kodi_utils.select_dialog([i[0] for i in choices], **kwargs)
-		if sort_how == None: return
-	from caches.trakt_cache import set_list_custom_sort
-	success = set_list_custom_sort(list_id, {'list_id': list_id, 'sort_by': sort_by, 'sort_how': sort_how})
-	if success:
-		kodi_utils.ok_dialog('Trakt List Custom Sort', 'Success')
-		kodi_utils.kodi_refresh()
-	else: kodi_utils.ok_dialog('Trakt List Custom Sort', 'An Error Occured')
+	"""Context menu entry for a Trakt user list. The dialog and the store both live elsewhere now.
+
+	sort_by/sort_how still ride in on the context menu URL. They are the ordering Trakt itself
+	declares for the list, which is what the list falls back to when no override is stored, so they
+	are passed on as the fallback for the "current" marker rather than being written anywhere.
+	"""
+	from indexers.dialogs import list_sort_override_choice
+	from modules import list_sort
+	fallback = list_sort.trakt_list_fallback(params.get('sort_by'), params.get('sort_how'))
+	list_sort_override_choice({'list_key': 'trakt.list:%s' % params['list_id'], 'adapter': 'trakt_list', 'fallback': fallback})

--- a/plugin.video.redlight/resources/lib/modules/list_sort.py
+++ b/plugin.video.redlight/resources/lib/modules/list_sort.py
@@ -1,0 +1,425 @@
+# -*- coding: utf-8 -*-
+"""Single sort model, engine and source adapters for every user-facing list.
+
+Deliberately free of Kodi and addon imports so it can be unit-tested directly.
+Settings and storage lookups are lazy imports inside functions.
+"""
+import re
+from random import random as _random
+
+MISSING_DATE = '2050-01-01'
+
+DEFAULT_SPEC = {'field': 'title', 'direction': 'asc'}
+
+VALID_FIELDS = ('title', 'date_added', 'release_date', 'rating', 'votes', 'runtime', 'rank', 'random', 'default')
+VALID_DIRECTIONS = ('asc', 'desc')
+
+# Fields whose ordering is not user-reversible.
+DIRECTIONLESS_FIELDS = ('random', 'default')
+
+FIELD_LABELS = {
+	'title': 'Title', 'date_added': 'Date Added', 'release_date': 'Release Date', 'rating': 'Rating',
+	'votes': 'Votes', 'runtime': 'Runtime', 'rank': 'Rank', 'random': 'Random', 'default': 'Provider Default'
+}
+
+DIRECTION_LABELS = {'asc': 'ascending', 'desc': 'descending'}
+
+_ARTICLE_RE = re.compile(r'^(the|a|an)\s+')
+
+
+def parse_spec(raw, fallback=None):
+	"""'date_added:desc' -> {'field': 'date_added', 'direction': 'desc'}. Never raises."""
+	if fallback is None: fallback = dict(DEFAULT_SPEC)
+	if not raw: return dict(fallback)
+	try:
+		parts = str(raw).split(':')
+		field = parts[0].strip()
+		direction = parts[1].strip() if len(parts) > 1 else 'asc'
+	except Exception:
+		return dict(fallback)
+	if field not in VALID_FIELDS: return dict(fallback)
+	if direction not in VALID_DIRECTIONS: direction = 'asc'
+	return {'field': field, 'direction': direction}
+
+
+def format_spec(spec):
+	return '%s:%s' % (spec.get('field', 'title'), spec.get('direction', 'asc'))
+
+
+def spec_label(spec):
+	field = spec.get('field', 'title')
+	label = FIELD_LABELS.get(field, field)
+	if field in DIRECTIONLESS_FIELDS: return label
+	return '%s (%s)' % (label, DIRECTION_LABELS.get(spec.get('direction', 'asc'), 'ascending'))
+
+
+def _safe_int(value, default):
+	"""Best-effort int() coercion for sort keys. Falls back to default on missing or malformed values
+	instead of raising, so one bad row from an external API can't silently unsort the whole list."""
+	if not value: return default
+	try:
+		return int(value)
+	except (TypeError, ValueError):
+		return default
+
+
+def strip_articles(title, ignore_articles):
+	"""Lower-cased sort key for a title. Strips a leading 'the '/'a '/'an ' when enabled.
+
+	The lower-casing is deliberate and is the one place this module does not reproduce the
+	pre-unification ordering: the old helpers compared raw titles in three of their four paths,
+	so 'iZombie' sorted after 'Zoo'. Ruled on and kept. Do not restore case sensitivity.
+	"""
+	try:
+		if title is None: return ''
+		title = str(title).lower()
+		if not ignore_articles: return title
+		return _ARTICLE_RE.sub('', title)
+	except Exception:
+		return ''
+
+
+def apply(data, spec, adapter, ignore_articles=False):
+	"""Return data sorted by spec using adapter's field extractors. Never raises.
+
+	Always returns a new list, never the caller's original object.
+	"""
+	if not data: return []
+	field = spec.get('field', 'title')
+	if field == 'default':
+		# 'default' means "the order the provider serves this list in". For most sources that is the
+		# order the payload already arrives in, so handing it back untouched is right. TMDb is not:
+		# pages 2..N are fetched by a thread pool and appended as they complete, so the assembled
+		# payload is page-interleaved. An adapter that can name the provider's order declares a
+		# 'default' extractor and it wins here; everything else keeps the pass-through.
+		default_extractor = adapter.get('fields', {}).get('default')
+		if default_extractor is None: return list(data)
+		try:
+			return sorted(data, key=default_extractor)
+		except Exception:
+			return list(data)
+	if field == 'random':
+		try:
+			return sorted(data, key=lambda k: _random())
+		except Exception:
+			return list(data)
+	extractor = adapter.get('fields', {}).get(field)
+	if extractor is None: return list(data)
+	reverse = spec.get('direction', 'asc') == 'desc'
+	if field == 'title':
+		key = lambda i: strip_articles(extractor(i), ignore_articles)
+	else:
+		key = extractor
+	try:
+		return sorted(data, key=key, reverse=reverse)
+	except Exception:
+		return list(data)
+
+
+def _node(item):
+	"""Trakt list rows nest the payload under a key named by item['type']."""
+	try: return item.get(item.get('type')) or {}
+	except Exception: return {}
+
+
+def _trakt_list_released(item):
+	node = _node(item)
+	if 'released' in node: return node.get('released') or MISSING_DATE
+	if 'first_aired' in node: return node.get('first_aired') or MISSING_DATE
+	return MISSING_DATE
+
+
+TRAKT_SYNC = {
+	'capabilities': ('title', 'date_added', 'release_date', 'random'),
+	'fields': {
+		'title': lambda i: i.get('title'),
+		'date_added': lambda i: i.get('collected_at') or '',
+		'release_date': lambda i: i.get('released') or MISSING_DATE,
+	}
+}
+
+TRAKT_LIST = {
+	'capabilities': ('title', 'date_added', 'release_date', 'rating', 'votes', 'runtime', 'rank', 'random', 'default'),
+	'fields': {
+		'title': lambda i: _node(i).get('title'),
+		'date_added': lambda i: i.get('listed_at') or '',
+		'release_date': _trakt_list_released,
+		'rating': lambda i: _node(i).get('rating') or 0,
+		'votes': lambda i: _node(i).get('votes') or 0,
+		'runtime': lambda i: _node(i).get('runtime') or 0,
+		'rank': lambda i: i.get('rank') or 0,
+	}
+}
+
+SIMKL = {
+	'capabilities': ('title', 'date_added', 'release_date', 'random', 'default'),
+	'fields': {
+		'title': lambda i: i.get('title'),
+		'date_added': lambda i: i.get('collected_at') or '',
+		'release_date': lambda i: i.get('released') or MISSING_DATE,
+	}
+}
+
+MDBLIST_WATCHLIST = {
+	'capabilities': ('title', 'date_added', 'release_date', 'random'),
+	'fields': {
+		'title': lambda i: i.get('title'),
+		'date_added': lambda i: i.get('watchlist_at') or '',
+		'release_date': lambda i: i.get('release_date') or MISSING_DATE,
+	}
+}
+
+# NOTE: this adapter's release_date extractor returns an integer year, not a date string like every
+# other adapter's. That is deliberate - the old MDBList collection code sorted on 'year', which is the
+# only date-ish field the payload carries - but it means the spec string 'release_date:desc' denotes
+# different data here than elsewhere. Keys from two adapters are never comparable; do not assume a
+# future shared sort UI can merge or compare them.
+MDBLIST_COLLECTION = {
+	'capabilities': ('title', 'date_added', 'release_date', 'random'),
+	'fields': {
+		'title': lambda i: i.get('title'),
+		'date_added': lambda i: i.get('collected_at') or '',
+		'release_date': lambda i: _safe_int(i.get('year'), 9999),
+	}
+}
+
+PERSONAL = {
+	'capabilities': ('title', 'date_added', 'release_date', 'random', 'default'),
+	'fields': {
+		'title': lambda i: i.get('title'),
+		'date_added': lambda i: _safe_int(i.get('date_added'), 0),
+		'release_date': lambda i: i.get('release_date') or MISSING_DATE,
+	}
+}
+
+# 'default' is a real sort here, not a pass-through: tmdblist_api stamps each row with the
+# original_order TMDb served it under, then fetches pages 2..N through a thread pool and extends the
+# result list in completion order. The old get_tmdb_list restored it explicitly for sort code 4
+# (the shipped default for Watchlist and Favorites), so without this extractor every multi-page TMDb
+# list comes back page-interleaved. The (is None, value) key mirrors the old sort exactly: rows with
+# no original_order sort last instead of raising against an int.
+TMDB = {
+	'capabilities': ('title', 'release_date', 'random', 'default'),
+	'fields': {
+		'title': lambda i: i.get('title'),
+		'release_date': lambda i: i.get('release_date') or MISSING_DATE,
+		'default': lambda i: (i.get('original_order') is None, _safe_int(i.get('original_order'), 0)),
+	}
+}
+
+ADAPTERS = {
+	'trakt_sync': TRAKT_SYNC, 'trakt_list': TRAKT_LIST, 'simkl': SIMKL,
+	'mdblist_watchlist': MDBLIST_WATCHLIST, 'mdblist_collection': MDBLIST_COLLECTION,
+	'personal': PERSONAL, 'tmdb': TMDB
+}
+
+
+def field_choices(adapter_name):
+	adapter = ADAPTERS.get(adapter_name)
+	if not adapter: return ()
+	return adapter['capabilities']
+
+
+DEFAULT_SETTING_IDS = {'movies': 'redlight.sort.default.movies', 'shows': 'redlight.sort.default.shows'}
+
+# The adapters the mediatype default actually governs: exactly those whose sort_source() call site
+# can pass a media type. resolve() consults DEFAULT_SETTING_IDS only when normalize_media_type()
+# returns non-empty, so a mixed list - a Trakt user list, a TMDb list, a personal list - never sees
+# the global default no matter what the picker offers.
+DEFAULT_GOVERNED_ADAPTERS = ('trakt_sync', 'simkl', 'mdblist_watchlist', 'mdblist_collection')
+
+
+def default_field_choices():
+	"""Fields every adapter the mediatype default governs can sort by, in VALID_FIELDS order.
+
+	Offering a wider set is silently broken: resolve() hands the spec to an adapter with no extractor
+	for that field, apply() returns the payload untouched and the list comes back in raw cache order
+	with no error anywhere. Derived from the adapters rather than hardcoded so a future adapter added
+	to DEFAULT_GOVERNED_ADAPTERS can only narrow the picker, never widen it.
+	"""
+	choice_sets = [set(field_choices(name)) for name in DEFAULT_GOVERNED_ADAPTERS]
+	if not choice_sets: return ()
+	common = set.intersection(*choice_sets)
+	return tuple(i for i in VALID_FIELDS if i in common)
+
+
+def resolve(list_key, media_type=None, fallback=None):
+	"""Per-list override, else the mediatype default, else fallback, else DEFAULT_SPEC.
+
+	fallback is a spec string for callers whose source carries its own ordering - a Trakt user list
+	whose payload declares sort_by/sort_how, or a TMDb list that is served in provider order. Those
+	lists have no mediatype (they are mixed), and a user who never opened "Set Custom Sort" has no
+	override row, so without it they would land on DEFAULT_SPEC and silently reorder on upgrade.
+	"""
+	from caches.list_sort_cache import scope_key, normalize_media_type, get_override
+	scope = scope_key(list_key, media_type)
+	raw = get_override(scope)
+	if raw:
+		spec = parse_spec(raw, fallback=None)
+		if format_spec(spec) == raw: return spec
+	normalized = normalize_media_type(media_type)
+	if not normalized: return parse_spec(fallback)
+	from caches.settings_cache import get_setting
+	return parse_spec(get_setting(DEFAULT_SETTING_IDS[normalized], ''))
+
+
+LEGACY_SYNC_CODES = {'0': 'title:asc', '1': 'date_added:desc', '2': 'release_date:desc', '3': 'date_added:asc', '4': 'release_date:asc'}
+
+# 'None' is the literal string the old TMDb sort picker stored for its "Default From TMDb (None)"
+# choice, and '' is what an empty row reads as; the old get_tmdb_list treated both as code 4
+# (original_order). Without them an explicit provider-order choice would be dropped in migration
+# and the list would come back as title:asc. migrate_legacy_sort_settings never reaches these keys:
+# _legacy_code() coerces a missing or blank setting to the '4' fallback before the lookup.
+LEGACY_TMDB_CODES = {'0': 'title:asc', '1': 'release_date:asc', '2': 'release_date:desc', '3': 'random:asc',
+	'4': 'default:asc', 'None': 'default:asc', '': 'default:asc'}
+
+# MDBList only ever honoured three of the five legacy codes (apis/mdblist_api.py:574-577, :585-588):
+# 2 -> release date / year descending, 1 -> watchlist_at / collected_at descending, and everything
+# else - including 0, 3 and 4 - falls through to title. Translating it through LEGACY_SYNC_CODES
+# would silently change the ordering of every MDBList list belonging to a user on code 3 or 4.
+LEGACY_MDBLIST_CODES = {'0': 'title:asc', '1': 'date_added:desc', '2': 'release_date:desc', '3': 'title:asc', '4': 'title:asc'}
+
+LEGACY_PERSONAL_CODES = {'0': 'title:asc', '1': 'date_added:asc', '2': 'date_added:desc', '3': 'release_date:asc',
+	'4': 'release_date:desc', '5': 'random:asc', 'None': 'default:asc', '': 'title:asc'}
+
+# Trakt user-list sort_by values -> canonical fields.
+LEGACY_TRAKT_FIELDS = {'added': 'date_added', 'released': 'release_date', 'popularity': 'votes', 'percentage': 'rating',
+	'title': 'title', 'runtime': 'runtime', 'rank': 'rank', 'votes': 'votes', 'random': 'random', 'default': 'default'}
+
+
+def translate_trakt_custom_sort(sort_by, sort_how):
+	"""Legacy Trakt per-list sort_by/sort_how -> 'field:direction'. '' when unmappable."""
+	field = LEGACY_TRAKT_FIELDS.get(sort_by)
+	if not field: return ''
+	direction = 'desc' if sort_how == 'desc' else 'asc'
+	return '%s:%s' % (field, direction)
+
+
+def trakt_list_fallback(sort_by, sort_how):
+	"""The ordering a Trakt user list has when nobody stored an override for it.
+
+	The list folder URL carries the sort_by/sort_how the Trakt API declared for the list - usually
+	'rank' - and the old code sorted by it. An unmappable value ('my_rating', 'watched', 'collected')
+	used to leave the payload untouched, so it maps to the provider order rather than to title.
+	"""
+	return translate_trakt_custom_sort(sort_by, sort_how) or 'default:asc'
+
+
+class SortMigrationError(Exception):
+	"""A translated sort preference could not be persisted."""
+
+
+# An absent row is not "no preference" - it is the fallback the old getter hardcoded, and the list was
+# ordered by it. lists_sort_order used int(get_setting('redlight.sort.%s', '0')) -> code 0 (title), and
+# tmdblists_sort_order used get_setting('redlight.tmdbsort.%s', '4') -> code 4 (provider order). Reading
+# a missing row as '' would map to nothing, write nothing, and let the scope inherit the new global
+# default (seeded from sort.watchlist) - silently reordering the list.
+LEGACY_SETTING_FALLBACKS = {'sort.watchlist': '0', 'sort.collection': '0', 'sort.simkl': '0',
+	'tmdbsort.watchlist': '4', 'tmdbsort.favorites': '4'}
+
+
+def _legacy_code(old_settings, setting_id):
+	"""The stored legacy code, or the fallback the old getter used when the row is absent or blank."""
+	fallback = LEGACY_SETTING_FALLBACKS[setting_id]
+	value = old_settings.get(setting_id, fallback)
+	if value is None or value == '': return fallback
+	return str(value)
+
+
+def migrate_legacy_sort_settings(old_settings):
+	"""Pure translation of the old settings dict into new defaults and overrides."""
+	defaults, overrides = {}, {}
+	watchlist_code = _legacy_code(old_settings, 'sort.watchlist')
+	collection_code = _legacy_code(old_settings, 'sort.collection')
+	watchlist_spec = LEGACY_SYNC_CODES.get(watchlist_code)
+	if watchlist_spec:
+		defaults['sort.default.movies'] = watchlist_spec
+		defaults['sort.default.shows'] = watchlist_spec
+	baseline = watchlist_spec or LEGACY_SYNC_CODES['0']
+	collection_spec = LEGACY_SYNC_CODES.get(collection_code)
+	if collection_spec and collection_spec != baseline:
+		overrides['trakt.collection:movies'] = collection_spec
+		overrides['trakt.collection:shows'] = collection_spec
+	# MDBList reads the same two settings but implements a different, narrower mapping, so it is
+	# always pinned explicitly. Inheriting the global default - which is seeded from sort.watchlist
+	# through LEGACY_SYNC_CODES - would give it an ordering it never honoured.
+	for legacy_code, list_key in ((watchlist_code, 'mdblist.watchlist'), (collection_code, 'mdblist.collection')):
+		mdblist_spec = LEGACY_MDBLIST_CODES.get(legacy_code)
+		if not mdblist_spec: continue
+		overrides['%s:movies' % list_key] = mdblist_spec
+		overrides['%s:shows' % list_key] = mdblist_spec
+	simkl_spec = LEGACY_SYNC_CODES.get(_legacy_code(old_settings, 'sort.simkl'))
+	if simkl_spec and simkl_spec != baseline:
+		overrides['simkl:movies'] = simkl_spec
+		overrides['simkl:shows'] = simkl_spec
+	for old_id, scope in (('tmdbsort.watchlist', 'tmdb:watchlist'), ('tmdbsort.favorites', 'tmdb:favorites')):
+		tmdb_spec = LEGACY_TMDB_CODES.get(_legacy_code(old_settings, old_id))
+		if tmdb_spec: overrides[scope] = tmdb_spec
+	return {'defaults': defaults, 'overrides': overrides}
+
+
+def run_sort_migration(old_settings, write_setting):
+	"""Apply the translation. write_setting(setting_id, value) persists a setting.
+
+	Returns True when anything was written, False when there was nothing to migrate. Note that
+	since every legacy setting is read through its documented fallback, an empty old_settings
+	dict still translates to the fallback ordering, so False is now a defensive case only.
+
+	Raises SortMigrationError when an override could not be persisted. set_override() swallows
+	its own exceptions and reports False, so an unwritable store would otherwise look like a
+	clean success and the caller would record the migration as done with the user's
+	preferences already deleted. Every override is attempted before raising, so a single bad
+	row does not discard the ones that can still be saved.
+	"""
+	result = migrate_legacy_sort_settings(old_settings)
+	if not result['defaults'] and not result['overrides']: return False
+	from caches.list_sort_cache import set_override
+	for setting_id, spec_string in result['defaults'].items():
+		write_setting(setting_id, spec_string)
+		write_setting('%s_name' % setting_id, spec_label(parse_spec(spec_string)))
+	failed = [scope for scope, spec_string in result['overrides'].items() if not set_override(scope, spec_string)]
+	if failed:
+		raise SortMigrationError('could not persist sort overrides: %s' % ', '.join(sorted(failed)))
+	return True
+
+
+def migrate_legacy_stores(trakt_rows, personal_rows, tmdb_rows):
+	"""Translate the three legacy per-list stores into {scope: spec_string}.
+
+	trakt_rows:    {list_id: {'sort_by':..., 'sort_how':...}}  (caches.trakt_cache.get_all_lists_custom_sort)
+	personal_rows: {(name, author): sort_order}
+	tmdb_rows:     {list_id: sort_order}
+	Unmappable rows are skipped rather than guessed.
+	"""
+	result = {}
+	for list_id, row in (trakt_rows or {}).items():
+		spec_string = translate_trakt_custom_sort(row.get('sort_by'), row.get('sort_how'))
+		if spec_string: result['trakt.list:%s' % list_id] = spec_string
+	for (name, author), sort_order in (personal_rows or {}).items():
+		spec_string = LEGACY_PERSONAL_CODES.get(str(sort_order))
+		if spec_string: result['personal:%s|%s' % (name, author)] = spec_string
+	for list_id, sort_order in (tmdb_rows or {}).items():
+		spec_string = LEGACY_TMDB_CODES.get(str(sort_order))
+		if spec_string: result['tmdb:%s' % list_id] = spec_string
+	return result
+
+
+def sort_source(data, list_key, media_type, adapter_name, fallback=None):
+	"""Resolve the spec for this list and media type, then sort. Never raises.
+
+	fallback is the spec string to use when the list has no override and no mediatype default;
+	see resolve(). Pass it wherever the source's own ordering must survive an upgrade.
+	"""
+	if not data: return data
+	adapter = ADAPTERS.get(adapter_name)
+	if not adapter: return data
+	try:
+		spec = resolve(list_key, media_type, fallback)
+	except Exception:
+		spec = parse_spec(fallback)
+	try:
+		from modules.settings import ignore_articles
+		articles = ignore_articles()
+	except Exception:
+		articles = False
+	return apply(data, spec, adapter, ignore_articles=articles)

--- a/plugin.video.redlight/resources/lib/modules/settings.py
+++ b/plugin.video.redlight/resources/lib/modules/settings.py
@@ -430,35 +430,6 @@ def trakt_sync_interval():
 def lists_sort_order(setting):
 	return int(get_setting('redlight.sort.%s' % setting, '0'))
 
-def sort_trakt_sync_list(data, setting_key):
-	"""Sort Trakt collection/watchlist rows. 0=title, 1/3=date added desc/asc, 2/4=release desc/asc."""
-	sort_order = lists_sort_order(setting_key)
-	if sort_order == 0:
-		from modules.utils import sort_for_article
-		return sort_for_article(data, 'title', ignore_articles())
-	if sort_order in (1, 3):
-		data.sort(key=lambda k: k.get('collected_at') or '', reverse=(sort_order == 1))
-	elif sort_order in (2, 4):
-		data.sort(key=lambda k: k.get('released') or '', reverse=(sort_order == 2))
-	return data
-
-def sort_simkl_personal_list(data):
-	"""Sort Simkl Plan to Watch / Watching / etc. Same order codes as sort_trakt_sync_list."""
-	try: sort_order = lists_sort_order('simkl')
-	except: sort_order = 0
-	if sort_order == 0:
-		from modules.utils import sort_for_article
-		return sort_for_article(data, 'title', ignore_articles())
-	if sort_order in (1, 3):
-		data.sort(key=lambda k: k.get('collected_at') or '', reverse=(sort_order == 1))
-	elif sort_order in (2, 4):
-		data.sort(key=lambda k: k.get('released') or '', reverse=(sort_order == 2))
-	return data
-
-def tmdblists_sort_order(setting):
-	if setting == 'recommendations': return None
-	return str(get_setting('redlight.tmdbsort.%s' % setting, '4'))
-
 def personal_lists_sort_unseen_to_top():
 	return get_setting('redlight.personal_list.sort_unseen_to_top') == 'true'
 

--- a/plugin.video.redlight/resources/lib/modules/utils.py
+++ b/plugin.video.redlight/resources/lib/modules/utils.py
@@ -280,44 +280,16 @@ def sec2time(sec, n_msec=3):
 	if d == 0: return pattern % (h, m, s)
 	return ('%d days, ' + pattern) % (d, h, m, s)
 
-def released_key(item):
-	if 'released' in item: return item['released'] or '2050-01-01'
-	if 'first_aired' in item: return item['first_aired'] or '2050-01-01'
-	return '2050-01-01'
-
 def title_key(title, ignore_articles):
-	if not ignore_articles: return title
-	try:
-		if title is None: title = ''
-		articles = ['the', 'a', 'an']
-		match = re.match(r'^((\w+)\s+)', title.lower())
-		if match and match.group(2) in articles: offset = len(match.group(1))
-		else: offset = 0
-		return title[offset:]
-	except: return title
+	from modules.list_sort import strip_articles
+	return strip_articles(title, ignore_articles)
 
 def sort_for_article(_list, _key, ignore_articles):
-	try:
-		if not ignore_articles: _list.sort(key=lambda k: k.get(_key))
-		else: _list.sort(key=lambda k: re.sub(r'(^the |^a |^an )', '', k.get(_key).lower()))
+	from modules.list_sort import strip_articles
+	try: _list.sort(key=lambda k: strip_articles(k.get(_key), ignore_articles))
 	except: pass
 	return _list
 	
-def sort_list(sort_key, sort_direction, list_data, ignore_articles):
-	try:
-		reverse = sort_direction != 'asc'
-		if sort_key == 'rank': return sorted(list_data, key=lambda x: x['rank'], reverse=reverse)
-		if sort_key == 'added': return sorted(list_data, key=lambda x: x['listed_at'], reverse=reverse)
-		if sort_key == 'title': return sorted(list_data, key=lambda x: title_key(x[x['type']].get('title'), ignore_articles), reverse=reverse)
-		if sort_key == 'released': return sorted(list_data, key=lambda x: released_key(x[x['type']]), reverse=reverse)
-		if sort_key == 'runtime': return sorted(list_data, key=lambda x: x[x['type']].get('runtime', 0), reverse=reverse)
-		if sort_key == 'popularity': return sorted(list_data, key=lambda x: x[x['type']].get('votes', 0), reverse=reverse)
-		if sort_key == 'percentage': return sorted(list_data, key=lambda x: x[x['type']].get('rating', 0), reverse=reverse)
-		if sort_key == 'votes': return sorted(list_data, key=lambda x: x[x['type']].get('votes', 0), reverse=reverse)
-		if sort_key == 'random': return sorted(list_data, key=lambda k: random.random())
-		return list_data
-	except: return list_data
-
 def paginate_list(item_list, page, limit=20, paginate_start=0):
 	if paginate_start:
 		item_list = item_list[paginate_start:]

--- a/plugin.video.redlight/resources/skins/Default/1080i/settings_manager.xml
+++ b/plugin.video.redlight/resources/skins/Default/1080i/settings_manager.xml
@@ -1199,69 +1199,28 @@
                           <property name="setting_description">Choose the sort order for your Watched media</property>
                           <onclick>RunPlugin(plugin://plugin.video.redlight/?mode=settings_manager.set_from_list&amp;setting_id=sort.watched)</onclick>
                       </item>
-        <!-- Contents Sort Order For Simkl Lists -->
+        <!-- List Sort Order -->
                       <item>
                           <visible>Container(2000).HasFocus(30)</visible>
-                          <property name="setting_label">Contents Sort Order For Simkl Lists</property>
+                          <property name="setting_label">List Sort Order</property>
                           <property name="setting_type">separator</property>
                           <onclick>noop</onclick>
                       </item>
                       <item>
                           <visible>Container(2000).HasFocus(30)</visible>
-                          <visible>!String.IsEqual(Window(10000).Property(redlight.simkl.user),empty_setting)</visible>
-                          <property name="setting_label">Simkl Lists</property>
+                          <property name="setting_label">Movies</property>
                           <property name="setting_type">action</property>
-                          <property name="setting_value">$INFO[Window(10000).Property(redlight.sort.simkl_name)]</property>
-                          <property name="setting_description">Sort order for Simkl Plan to Watch, Watching, Completed, On Hold, and Dropped. Release Date uses Simkl year or release metadata (TV uses premiere year when full air date is unavailable).</property>
-                          <onclick>RunPlugin(plugin://plugin.video.redlight/?mode=settings_manager.set_from_list&amp;setting_id=sort.simkl)</onclick>
-                      </item>
-        <!-- Contents Sort Order For Trakt Lists -->
-                      <item>
-                          <visible>Container(2000).HasFocus(30)</visible>
-                          <property name="setting_label">Contents Sort Order For Trakt Lists</property>
-                          <property name="setting_type">separator</property>
-                          <onclick>noop</onclick>
+                          <property name="setting_value">$INFO[Window(10000).Property(redlight.sort.default.movies_name)]</property>
+                          <property name="setting_description">Default sort order for movie lists - Watchlist, Collection, Simkl and MDBList. Individual lists can override this from their context menu.</property>
+                          <onclick>RunPlugin(plugin://plugin.video.redlight/?mode=sort_default_choice&amp;media_type=movies)</onclick>
                       </item>
                       <item>
                           <visible>Container(2000).HasFocus(30)</visible>
-                          <visible>!String.IsEqual(Window(10000).Property(redlight.trakt.user),empty_setting)</visible>
-                          <property name="setting_label">Trakt Collection</property>
+                          <property name="setting_label">TV Shows</property>
                           <property name="setting_type">action</property>
-                          <property name="setting_value">$INFO[Window(10000).Property(redlight.sort.collection_name)]</property>
-                          <property name="setting_description">Choose the sort order for your Trakt Collection media. Release Date uses movie release / TV first-air date.</property>
-                          <onclick>RunPlugin(plugin://plugin.video.redlight/?mode=settings_manager.set_from_list&amp;setting_id=sort.collection)</onclick>
-                      </item>
-                      <item>
-                          <visible>Container(2000).HasFocus(30)</visible>
-                          <visible>!String.IsEqual(Window(10000).Property(redlight.trakt.user),empty_setting)</visible>
-                          <property name="setting_label">Trakt Watchlist</property>
-                          <property name="setting_type">action</property>
-                          <property name="setting_value">$INFO[Window(10000).Property(redlight.sort.watchlist_name)]</property>
-                          <property name="setting_description">Choose the sort order for your Trakt Watchlist media. Release Date uses movie release / TV first-air date.</property>
-                          <onclick>RunPlugin(plugin://plugin.video.redlight/?mode=settings_manager.set_from_list&amp;setting_id=sort.watchlist)</onclick>
-                      </item>
-        <!-- Contents Sort Order For TMDb Lists -->
-                      <item>
-                          <visible>Container(2000).HasFocus(30)</visible>
-                          <property name="setting_label">Contents Sort Order For TMDb Lists</property>
-                          <property name="setting_type">separator</property>
-                          <onclick>noop</onclick>
-                      </item>
-                      <item>
-                          <visible>Container(2000).HasFocus(30)</visible>
-                          <property name="setting_label">TMDb Watchlist</property>
-                          <property name="setting_type">action</property>
-                          <property name="setting_value">$INFO[Window(10000).Property(redlight.tmdbsort.watchlist_name)]</property>
-                          <property name="setting_description">Choose the sort order for your TMDb Watchlist media</property>
-                          <onclick>RunPlugin(plugin://plugin.video.redlight/?mode=settings_manager.set_from_list&amp;setting_id=tmdbsort.watchlist)</onclick>
-                      </item>
-                      <item>
-                          <visible>Container(2000).HasFocus(30)</visible>
-                          <property name="setting_label">TMDb Favorites</property>
-                          <property name="setting_type">action</property>
-                          <property name="setting_value">$INFO[Window(10000).Property(redlight.tmdbsort.favorites_name)]</property>
-                          <property name="setting_description">Choose the sort order for your TMDb Favorites media</property>
-                          <onclick>RunPlugin(plugin://plugin.video.redlight/?mode=settings_manager.set_from_list&amp;setting_id=tmdbsort.favorites)</onclick>
+                          <property name="setting_value">$INFO[Window(10000).Property(redlight.sort.default.shows_name)]</property>
+                          <property name="setting_description">Default sort order for TV show lists - Watchlist, Collection, Simkl and MDBList. Individual lists can override this from their context menu.</property>
+                          <onclick>RunPlugin(plugin://plugin.video.redlight/?mode=sort_default_choice&amp;media_type=shows)</onclick>
                       </item>
         <!-- TMDb Lists -->
                       <item>

--- a/tests/test_base_cache_databases.py
+++ b/tests/test_base_cache_databases.py
@@ -1,0 +1,92 @@
+"""remove_old_databases() must never delete a database the addon still uses.
+
+The allowlist it checks against used to be hand-maintained, and it had drifted: four entries were
+database *keys* ('personal_lists_db', 'random_widgets_db', 'episode_groups_db') rather than the
+filenames list_dirs() actually returns, so personal_lists.db and random_widgets.db fell outside the
+allowlist and would have been deleted as stale. The invariant that matters is not "these twenty
+names are right" but "every file locations() names is current", which is what these tests pin.
+
+base_cache is compiled straight out of caches/base_cache.py against stub globals rather than
+imported: the module pulls in modules.kodi_utils and therefore the whole Kodi runtime, while the two
+functions under test only touch kodi_utils.addon_profile / list_dirs / delete_file.
+"""
+import ast
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+BASE_CACHE = ROOT / 'plugin.video.redlight' / 'resources' / 'lib' / 'caches' / 'base_cache.py'
+
+_WANTED = ('locations', 'remove_old_databases')
+
+
+class _KodiUtils:
+	"""The slice of modules.kodi_utils the two functions touch."""
+
+	def __init__(self, files):
+		self.files = list(files)
+		self.deleted = []
+
+	@staticmethod
+	def addon_profile(): return 'profile/'
+
+	def list_dirs(self, _path): return ([], list(self.files))
+
+	def delete_file(self, filepath): self.deleted.append(filepath)
+
+
+def _load(kodi_utils):
+	with open(str(BASE_CACHE), 'r', encoding='utf-8') as f:
+		tree = ast.parse(f.read())
+	body = [n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name in _WANTED]
+	if len(body) != len(_WANTED): raise AssertionError('expected exactly one def of each of %s' % (_WANTED,))
+	module = ast.fix_missing_locations(ast.Module(body=body, type_ignores=[]))
+	namespace = {'kodi_utils': kodi_utils, 'path': __import__('os').path}
+	exec(compile(module, '<base_cache>', 'exec'), namespace)
+	return namespace
+
+
+class RemoveOldDatabasesTests(unittest.TestCase):
+	def test_every_database_locations_names_is_treated_as_current(self):
+		"""The invariant. Add a database to locations() and it is protected for free."""
+		namespace = _load(_KodiUtils([]))
+		filenames = list(namespace['locations']().values())
+		kodi_utils = _KodiUtils(filenames)
+		namespace = _load(kodi_utils)
+		namespace['remove_old_databases']()
+		self.assertEqual([], kodi_utils.deleted)
+
+	def test_the_two_databases_the_stale_allowlist_missed_survive(self):
+		"""The regression itself: both files were named by key, not filename, and were deleted."""
+		kodi_utils = _KodiUtils(['personal_lists.db', 'random_widgets.db', 'episode_groups.db', 'list_sort.db'])
+		_load(kodi_utils)['remove_old_databases']()
+		self.assertEqual([], kodi_utils.deleted)
+
+	def test_no_allowlist_entry_is_a_database_key(self):
+		"""list_dirs() yields filenames, so a key in the allowlist protects nothing and hides a file."""
+		namespace = _load(_KodiUtils([]))
+		locations = namespace['locations']()
+		kodi_utils = _KodiUtils(list(locations.keys()))
+		_load(kodi_utils)['remove_old_databases']()
+		self.assertEqual(sorted('profile/databases/' + k for k in locations),
+			sorted(kodi_utils.deleted))
+
+	def test_a_genuinely_stale_file_is_still_deleted(self):
+		"""Widening the allowlist must not turn the function into a no-op."""
+		namespace = _load(_KodiUtils([]))
+		filenames = list(namespace['locations']().values())
+		kodi_utils = _KodiUtils(filenames + ['retired.db'])
+		_load(kodi_utils)['remove_old_databases']()
+		self.assertEqual(['profile/databases/retired.db'], kodi_utils.deleted)
+
+	def test_every_location_is_a_db_filename(self):
+		"""A key that looks like a filename would slip past the test above."""
+		locations = _load(_KodiUtils([]))['locations']()
+		for key, filename in locations.items():
+			self.assertTrue(filename.endswith('.db'), '%s -> %s' % (key, filename))
+			self.assertNotIn(filename, locations, '%s -> %s is a key, not a filename' % (key, filename))
+		self.assertEqual(len(locations), len(set(locations.values())))
+
+
+if __name__ == '__main__':
+	unittest.main()

--- a/tests/test_list_sort_adapters.py
+++ b/tests/test_list_sort_adapters.py
@@ -1,0 +1,194 @@
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+LIST_SORT_PATH = ROOT / 'plugin.video.redlight' / 'resources' / 'lib' / 'modules' / 'list_sort.py'
+
+
+def _load_list_sort_module():
+	spec = importlib.util.spec_from_file_location('list_sort_adapters_under_test', LIST_SORT_PATH)
+	module = importlib.util.module_from_spec(spec)
+	spec.loader.exec_module(module)
+	return module
+
+
+list_sort = _load_list_sort_module()
+
+
+class AdapterRegistryTests(unittest.TestCase):
+	def test_all_adapters_registered(self):
+		expected = {'trakt_sync', 'trakt_list', 'simkl', 'mdblist_watchlist', 'mdblist_collection', 'personal', 'tmdb'}
+		self.assertEqual(expected, set(list_sort.ADAPTERS))
+
+	def test_capabilities_are_valid_fields(self):
+		for name, adapter in list_sort.ADAPTERS.items():
+			for field in adapter['capabilities']:
+				self.assertIn(field, list_sort.VALID_FIELDS, '%s declares unknown field %s' % (name, field))
+
+	def test_every_capability_has_an_extractor_or_is_synthetic(self):
+		synthetic = ('random', 'default')
+		for name, adapter in list_sort.ADAPTERS.items():
+			for field in adapter['capabilities']:
+				if field in synthetic: continue
+				self.assertIn(field, adapter['fields'], '%s declares %s with no extractor' % (name, field))
+
+	def test_field_choices_returns_capabilities(self):
+		self.assertEqual(list_sort.ADAPTERS['tmdb']['capabilities'], list_sort.field_choices('tmdb'))
+
+	def test_field_choices_unknown_adapter_is_empty(self):
+		self.assertEqual((), list_sort.field_choices('nope'))
+
+
+class TraktSyncAdapterTests(unittest.TestCase):
+	def setUp(self):
+		self.data = [
+			{'title': 'B', 'collected_at': '2024-02-01', 'released': '2001-01-01'},
+			{'title': 'A', 'collected_at': '2024-03-01', 'released': '1999-01-01'},
+		]
+
+	def test_date_added_reads_collected_at(self):
+		result = list_sort.apply(self.data, {'field': 'date_added', 'direction': 'desc'}, list_sort.TRAKT_SYNC)
+		self.assertEqual(['A', 'B'], [i['title'] for i in result])
+
+	def test_release_date_missing_uses_sentinel(self):
+		data = [{'title': 'A', 'collected_at': '', 'released': None}, {'title': 'B', 'collected_at': '', 'released': '1999-01-01'}]
+		result = list_sort.apply(data, {'field': 'release_date', 'direction': 'asc'}, list_sort.TRAKT_SYNC)
+		self.assertEqual(['B', 'A'], [i['title'] for i in result])
+
+
+class SimklAdapterTests(unittest.TestCase):
+	def test_date_added_reads_collected_at(self):
+		data = [{'title': 'B', 'collected_at': '2024-02-01', 'released': '2001-01-01'},
+			{'title': 'A', 'collected_at': '2024-03-01', 'released': '1999-01-01'}]
+		result = list_sort.apply(data, {'field': 'date_added', 'direction': 'desc'}, list_sort.SIMKL)
+		self.assertEqual(['A', 'B'], [i['title'] for i in result])
+
+	def test_release_date_reads_released(self):
+		data = [{'title': 'B', 'collected_at': '', 'released': '2001-01-01'},
+			{'title': 'A', 'collected_at': '', 'released': '1999-01-01'}]
+		result = list_sort.apply(data, {'field': 'release_date', 'direction': 'asc'}, list_sort.SIMKL)
+		self.assertEqual(['A', 'B'], [i['title'] for i in result])
+
+	def test_release_date_missing_uses_sentinel(self):
+		data = [{'title': 'A', 'collected_at': '', 'released': None}, {'title': 'B', 'collected_at': '', 'released': '1999-01-01'}]
+		result = list_sort.apply(data, {'field': 'release_date', 'direction': 'asc'}, list_sort.SIMKL)
+		self.assertEqual(['B', 'A'], [i['title'] for i in result])
+
+
+class TraktListAdapterTests(unittest.TestCase):
+	def setUp(self):
+		self.data = [
+			{'type': 'movie', 'rank': 2, 'listed_at': '2024-01-01', 'movie': {'title': 'B', 'released': '2001-01-01', 'rating': 5.0, 'votes': 10, 'runtime': 100}},
+			{'type': 'show', 'rank': 1, 'listed_at': '2024-02-01', 'show': {'title': 'A', 'first_aired': '1999-01-01', 'rating': 9.0, 'votes': 20, 'runtime': 40}},
+		]
+
+	def test_title_reads_nested_node(self):
+		result = list_sort.apply(self.data, {'field': 'title', 'direction': 'asc'}, list_sort.TRAKT_LIST)
+		self.assertEqual([2, 1], [i['rank'] for i in result][::-1])
+
+	def test_rank_ascending(self):
+		result = list_sort.apply(self.data, {'field': 'rank', 'direction': 'asc'}, list_sort.TRAKT_LIST)
+		self.assertEqual([1, 2], [i['rank'] for i in result])
+
+	def test_release_date_falls_back_to_first_aired(self):
+		result = list_sort.apply(self.data, {'field': 'release_date', 'direction': 'asc'}, list_sort.TRAKT_LIST)
+		self.assertEqual(['show', 'movie'], [i['type'] for i in result])
+
+	def test_votes_descending(self):
+		result = list_sort.apply(self.data, {'field': 'votes', 'direction': 'desc'}, list_sort.TRAKT_LIST)
+		self.assertEqual(['show', 'movie'], [i['type'] for i in result])
+
+	def test_missing_node_does_not_raise(self):
+		data = [{'type': 'movie'}, {'type': 'show', 'show': {'title': 'A'}}]
+		result = list_sort.apply(data, {'field': 'title', 'direction': 'asc'}, list_sort.TRAKT_LIST)
+		self.assertEqual(2, len(result))
+
+
+class MdblistAdapterTests(unittest.TestCase):
+	def test_watchlist_date_added_reads_watchlist_at(self):
+		data = [{'title': 'B', 'watchlist_at': '2024-01-01', 'release_date': '2001-01-01'},
+			{'title': 'A', 'watchlist_at': '2024-02-01', 'release_date': '1999-01-01'}]
+		result = list_sort.apply(data, {'field': 'date_added', 'direction': 'desc'}, list_sort.MDBLIST_WATCHLIST)
+		self.assertEqual(['A', 'B'], [i['title'] for i in result])
+
+	def test_collection_release_date_reads_year(self):
+		data = [{'title': 'B', 'collected_at': '', 'year': 2001}, {'title': 'A', 'collected_at': '', 'year': 1999}]
+		result = list_sort.apply(data, {'field': 'release_date', 'direction': 'asc'}, list_sort.MDBLIST_COLLECTION)
+		self.assertEqual(['A', 'B'], [i['title'] for i in result])
+
+	def test_collection_missing_year_sorts_last(self):
+		data = [{'title': 'B', 'collected_at': '', 'year': None}, {'title': 'A', 'collected_at': '', 'year': 1999}]
+		result = list_sort.apply(data, {'field': 'release_date', 'direction': 'asc'}, list_sort.MDBLIST_COLLECTION)
+		self.assertEqual(['A', 'B'], [i['title'] for i in result])
+
+	def test_collection_malformed_year_sorts_last_without_unsorting_others(self):
+		data = [
+			{'title': 'C', 'collected_at': '', 'year': 'TBA'},
+			{'title': 'B', 'collected_at': '', 'year': 2001},
+			{'title': 'A', 'collected_at': '', 'year': 1999},
+		]
+		result = list_sort.apply(data, {'field': 'release_date', 'direction': 'asc'}, list_sort.MDBLIST_COLLECTION)
+		self.assertEqual(['A', 'B', 'C'], [i['title'] for i in result])
+
+
+class PersonalAdapterTests(unittest.TestCase):
+	def test_date_added_compares_numerically(self):
+		data = [{'title': 'B', 'date_added': '100', 'release_date': None}, {'title': 'A', 'date_added': '20', 'release_date': None}]
+		result = list_sort.apply(data, {'field': 'date_added', 'direction': 'asc'}, list_sort.PERSONAL)
+		self.assertEqual(['A', 'B'], [i['title'] for i in result])
+
+	def test_missing_release_date_sorts_last(self):
+		data = [{'title': 'B', 'date_added': '1', 'release_date': None}, {'title': 'A', 'date_added': '2', 'release_date': '1999-01-01'}]
+		result = list_sort.apply(data, {'field': 'release_date', 'direction': 'asc'}, list_sort.PERSONAL)
+		self.assertEqual(['A', 'B'], [i['title'] for i in result])
+
+	def test_malformed_date_added_sorts_last_without_unsorting_others(self):
+		data = [
+			{'title': 'C', 'date_added': 'corrupt', 'release_date': None},
+			{'title': 'B', 'date_added': '100', 'release_date': None},
+			{'title': 'A', 'date_added': '20', 'release_date': None},
+		]
+		result = list_sort.apply(data, {'field': 'date_added', 'direction': 'asc'}, list_sort.PERSONAL)
+		self.assertEqual(['C', 'A', 'B'], [i['title'] for i in result])
+
+
+class TmdbAdapterTests(unittest.TestCase):
+	def test_default_field_restores_provider_order(self):
+		# The rows arrive out of original_order on purpose: tmdblist_api appends pages 2..N in thread
+		# completion order, so the payload order is not TMDb's. A fixture already in original_order
+		# would pass against an engine that simply returned the payload untouched.
+		data = [{'title': 'B', 'original_order': 1, 'release_date': None},
+			{'title': 'C', 'original_order': 2, 'release_date': None},
+			{'title': 'A', 'original_order': 0, 'release_date': None}]
+		result = list_sort.apply(data, {'field': 'default', 'direction': 'asc'}, list_sort.TMDB)
+		self.assertEqual(['A', 'B', 'C'], [i['title'] for i in result])
+
+	def test_default_field_ignores_direction(self):
+		# 'default' is in DIRECTIONLESS_FIELDS; a stored 'default:desc' must not reverse the list.
+		data = [{'title': 'B', 'original_order': 1}, {'title': 'A', 'original_order': 0}]
+		result = list_sort.apply(data, {'field': 'default', 'direction': 'desc'}, list_sort.TMDB)
+		self.assertEqual(['A', 'B'], [i['title'] for i in result])
+
+	def test_default_field_missing_original_order_sorts_last(self):
+		data = [{'title': 'X'}, {'title': 'B', 'original_order': 1}, {'title': 'A', 'original_order': 0}]
+		result = list_sort.apply(data, {'field': 'default', 'direction': 'asc'}, list_sort.TMDB)
+		self.assertEqual(['A', 'B', 'X'], [i['title'] for i in result])
+
+	def test_adapters_without_a_default_extractor_hand_the_payload_back(self):
+		# Only TMDb declares one. Every other adapter's 'default' must stay the pass-through it was,
+		# or their provider ordering changes on upgrade too.
+		data = [{'title': 'B'}, {'title': 'A'}]
+		for name in ('trakt_list', 'simkl', 'personal'):
+			adapter = list_sort.ADAPTERS[name]
+			self.assertNotIn('default', adapter['fields'], name)
+			result = list_sort.apply(data, {'field': 'default', 'direction': 'asc'}, adapter)
+			self.assertEqual(['B', 'A'], [i['title'] for i in result], name)
+
+	def test_tmdb_has_no_date_added(self):
+		self.assertNotIn('date_added', list_sort.TMDB['capabilities'])
+
+
+if __name__ == '__main__':
+	unittest.main()

--- a/tests/test_list_sort_cache.py
+++ b/tests/test_list_sort_cache.py
@@ -1,0 +1,134 @@
+import ast
+import importlib.util
+import inspect
+import sqlite3
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CACHE_PATH = ROOT / 'plugin.video.redlight' / 'resources' / 'lib' / 'caches' / 'list_sort_cache.py'
+
+SCHEMA = 'CREATE TABLE IF NOT EXISTS list_sort (scope text unique, spec text)'
+
+
+def _load_module(connection):
+	caches = types.ModuleType('caches')
+	caches.__path__ = []
+	base_cache = types.ModuleType('caches.base_cache')
+	base_cache.connect_database = lambda name: connection
+	modules = types.ModuleType('modules')
+	modules.__path__ = []
+	kodi_utils = types.ModuleType('modules.kodi_utils')
+	kodi_utils.logger = lambda *args, **kwargs: None
+	sys.modules['caches'] = caches
+	sys.modules['caches.base_cache'] = base_cache
+	sys.modules['modules'] = modules
+	sys.modules['modules.kodi_utils'] = kodi_utils
+	spec = importlib.util.spec_from_file_location('list_sort_cache_under_test', CACHE_PATH)
+	module = importlib.util.module_from_spec(spec)
+	spec.loader.exec_module(module)
+	return module
+
+
+class ScopeKeyTests(unittest.TestCase):
+	@classmethod
+	def setUpClass(cls):
+		cls.connection = sqlite3.connect(':memory:')
+		cls.connection.execute(SCHEMA)
+		cls.module = _load_module(cls.connection)
+
+	def test_media_type_is_appended(self):
+		self.assertEqual('trakt.watchlist:movies', self.module.scope_key('trakt.watchlist', 'movies'))
+
+	def test_media_type_is_normalised(self):
+		self.assertEqual('trakt.watchlist:shows', self.module.scope_key('trakt.watchlist', 'show'))
+		self.assertEqual('trakt.watchlist:movies', self.module.scope_key('trakt.watchlist', 'movie'))
+
+	def test_mixed_media_lists_have_no_suffix(self):
+		self.assertEqual('trakt.list:12345', self.module.scope_key('trakt.list:12345'))
+
+	def test_unknown_media_type_is_dropped(self):
+		self.assertEqual('trakt.watchlist', self.module.scope_key('trakt.watchlist', 'anime'))
+
+
+class OverrideStoreTests(unittest.TestCase):
+	def setUp(self):
+		self.connection = sqlite3.connect(':memory:')
+		self.connection.execute(SCHEMA)
+		self.module = _load_module(self.connection)
+
+	def test_missing_override_is_empty_string(self):
+		self.assertEqual('', self.module.get_override('trakt.watchlist:movies'))
+
+	def test_set_then_get(self):
+		self.assertTrue(self.module.set_override('trakt.watchlist:movies', 'date_added:desc'))
+		self.assertEqual('date_added:desc', self.module.get_override('trakt.watchlist:movies'))
+
+	def test_set_replaces_existing(self):
+		self.module.set_override('trakt.watchlist:movies', 'date_added:desc')
+		self.module.set_override('trakt.watchlist:movies', 'title:asc')
+		self.assertEqual('title:asc', self.module.get_override('trakt.watchlist:movies'))
+
+	def test_delete_removes_row(self):
+		self.module.set_override('trakt.watchlist:movies', 'title:asc')
+		self.assertTrue(self.module.delete_override('trakt.watchlist:movies'))
+		self.assertEqual('', self.module.get_override('trakt.watchlist:movies'))
+
+	def test_delete_missing_row_succeeds(self):
+		self.assertTrue(self.module.delete_override('nothing.here'))
+
+	def test_get_all_returns_every_row(self):
+		self.module.set_override('trakt.watchlist:movies', 'title:asc')
+		self.module.set_override('trakt.collection:shows', 'rating:desc')
+		self.assertEqual({'trakt.watchlist:movies': 'title:asc', 'trakt.collection:shows': 'rating:desc'},
+			self.module.get_all_overrides())
+
+	def test_get_all_on_empty_table(self):
+		self.assertEqual({}, self.module.get_all_overrides())
+
+	def test_get_all_coerces_null_spec_to_empty_string(self):
+		self.connection.execute('INSERT INTO list_sort (scope, spec) VALUES (?, ?)', ('trakt.watchlist:movies', None))
+		self.assertEqual({'trakt.watchlist:movies': ''}, self.module.get_all_overrides())
+
+
+class DatabaseRegistrationTests(unittest.TestCase):
+	"""Guard against repeating the list_sort_db integrity_check omission for future database additions."""
+
+	@classmethod
+	def setUpClass(cls):
+		modules = sys.modules.get('modules') or types.ModuleType('modules')
+		modules.__path__ = []
+		kodi_utils = types.ModuleType('modules.kodi_utils')
+		kodi_utils.logger = lambda *args, **kwargs: None
+		sys.modules['modules'] = modules
+		sys.modules['modules.kodi_utils'] = kodi_utils
+		base_cache_path = CACHE_PATH.parent / 'base_cache.py'
+		spec = importlib.util.spec_from_file_location('base_cache_under_test', base_cache_path)
+		module = importlib.util.module_from_spec(spec)
+		spec.loader.exec_module(module)
+		cls.module = module
+
+	def test_list_sort_db_registered_in_table_creators(self):
+		self.assertIn('list_sort_db', self.module.table_creators())
+
+	def test_list_sort_db_registered_in_locations(self):
+		self.assertIn('list_sort_db', self.module.locations())
+
+	def test_list_sort_db_registered_in_integrity_check(self):
+		# integrity_check is a local dict inside check_databases_integrity, not returned by the
+		# function, so parse the source to recover its keys rather than duplicating the dict here.
+		source = inspect.getsource(self.module.check_databases_integrity)
+		tree = ast.parse(source)
+		function_def = tree.body[0]
+		assign = next(
+			node for node in ast.walk(function_def)
+			if isinstance(node, ast.Assign) and any(getattr(t, 'id', None) == 'integrity_check' for t in node.targets))
+		integrity_check = ast.literal_eval(assign.value)
+		self.assertIn('list_sort_db', integrity_check)
+
+
+if __name__ == '__main__':
+	unittest.main()

--- a/tests/test_list_sort_engine.py
+++ b/tests/test_list_sort_engine.py
@@ -1,0 +1,153 @@
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+LIST_SORT_PATH = ROOT / 'plugin.video.redlight' / 'resources' / 'lib' / 'modules' / 'list_sort.py'
+
+
+def _load_list_sort_module():
+	spec = importlib.util.spec_from_file_location('list_sort_under_test', LIST_SORT_PATH)
+	module = importlib.util.module_from_spec(spec)
+	spec.loader.exec_module(module)
+	return module
+
+
+list_sort = _load_list_sort_module()
+
+ADAPTER = {
+	'capabilities': ('title', 'date_added', 'release_date', 'rating', 'random', 'default'),
+	'fields': {
+		'title': lambda i: i.get('title'),
+		'date_added': lambda i: i.get('added') or '',
+		'release_date': lambda i: i.get('released') or '2050-01-01',
+		'rating': lambda i: i.get('rating') or 0,
+	},
+}
+
+
+class ParseSpecTests(unittest.TestCase):
+	def test_parses_field_and_direction(self):
+		self.assertEqual({'field': 'date_added', 'direction': 'desc'}, list_sort.parse_spec('date_added:desc'))
+
+	def test_missing_direction_defaults_to_asc(self):
+		self.assertEqual({'field': 'title', 'direction': 'asc'}, list_sort.parse_spec('title'))
+
+	def test_unknown_field_falls_back(self):
+		self.assertEqual(list_sort.DEFAULT_SPEC, list_sort.parse_spec('nonsense:desc'))
+
+	def test_unknown_direction_falls_back_to_asc(self):
+		self.assertEqual({'field': 'title', 'direction': 'asc'}, list_sort.parse_spec('title:sideways'))
+
+	def test_empty_uses_supplied_fallback(self):
+		fallback = {'field': 'rating', 'direction': 'desc'}
+		self.assertEqual(fallback, list_sort.parse_spec('', fallback))
+
+	def test_roundtrips_through_format(self):
+		self.assertEqual('release_date:desc', list_sort.format_spec({'field': 'release_date', 'direction': 'desc'}))
+
+
+class SpecLabelTests(unittest.TestCase):
+	def test_labels_field_and_direction(self):
+		self.assertEqual('Date Added (descending)', list_sort.spec_label({'field': 'date_added', 'direction': 'desc'}))
+
+	def test_directionless_fields_omit_direction(self):
+		self.assertEqual('Random', list_sort.spec_label({'field': 'random', 'direction': 'asc'}))
+		self.assertEqual('Provider Default', list_sort.spec_label({'field': 'default', 'direction': 'asc'}))
+
+
+class StripArticlesTests(unittest.TestCase):
+	def test_strips_leading_article_when_enabled(self):
+		self.assertEqual('matrix', list_sort.strip_articles('The Matrix', True))
+
+	def test_keeps_article_when_disabled(self):
+		self.assertEqual('the matrix', list_sort.strip_articles('The Matrix', False))
+
+	def test_only_strips_whole_words(self):
+		self.assertEqual('theodore rex', list_sort.strip_articles('Theodore Rex', True))
+
+	def test_handles_none(self):
+		self.assertEqual('', list_sort.strip_articles(None, True))
+
+
+class ApplyTests(unittest.TestCase):
+	def setUp(self):
+		self.data = [
+			{'title': 'Banana', 'added': '2024-01-02', 'released': '2001-01-01', 'rating': 5.0},
+			{'title': 'The Apple', 'added': '2024-01-03', 'released': None, 'rating': 9.0},
+			{'title': 'cherry', 'added': '2024-01-01', 'released': '1999-01-01', 'rating': 7.0},
+		]
+
+	def _titles(self, result):
+		return [i['title'] for i in result]
+
+	def test_title_ascending_is_case_insensitive(self):
+		result = list_sort.apply(self.data, {'field': 'title', 'direction': 'asc'}, ADAPTER, ignore_articles=False)
+		self.assertEqual(['Banana', 'cherry', 'The Apple'], self._titles(result))
+
+	def test_title_ascending_ignoring_articles(self):
+		result = list_sort.apply(self.data, {'field': 'title', 'direction': 'asc'}, ADAPTER, ignore_articles=True)
+		self.assertEqual(['The Apple', 'Banana', 'cherry'], self._titles(result))
+
+	def test_title_descending_reverses_article_stripped_order(self):
+		result = list_sort.apply(self.data, {'field': 'title', 'direction': 'desc'}, ADAPTER, ignore_articles=True)
+		self.assertEqual(['cherry', 'Banana', 'The Apple'], self._titles(result))
+
+	def test_date_added_descending(self):
+		result = list_sort.apply(self.data, {'field': 'date_added', 'direction': 'desc'}, ADAPTER)
+		self.assertEqual(['The Apple', 'Banana', 'cherry'], self._titles(result))
+
+	def test_release_date_missing_sorts_last_ascending(self):
+		result = list_sort.apply(self.data, {'field': 'release_date', 'direction': 'asc'}, ADAPTER)
+		self.assertEqual(['cherry', 'Banana', 'The Apple'], self._titles(result))
+
+	def test_rating_descending(self):
+		result = list_sort.apply(self.data, {'field': 'rating', 'direction': 'desc'}, ADAPTER)
+		self.assertEqual(['The Apple', 'cherry', 'Banana'], self._titles(result))
+
+	def test_default_field_preserves_input_order(self):
+		result = list_sort.apply(self.data, {'field': 'default', 'direction': 'asc'}, ADAPTER)
+		self.assertEqual(['Banana', 'The Apple', 'cherry'], self._titles(result))
+
+	def test_field_unsupported_by_adapter_preserves_order(self):
+		result = list_sort.apply(self.data, {'field': 'runtime', 'direction': 'asc'}, ADAPTER)
+		self.assertEqual(['Banana', 'The Apple', 'cherry'], self._titles(result))
+
+	def test_random_returns_same_membership(self):
+		result = list_sort.apply(self.data, {'field': 'random', 'direction': 'asc'}, ADAPTER)
+		self.assertEqual(sorted(self._titles(self.data)), sorted(self._titles(result)))
+
+	def test_empty_input_returns_empty(self):
+		self.assertEqual([], list_sort.apply([], {'field': 'title', 'direction': 'asc'}, ADAPTER))
+
+	def test_extractor_raising_preserves_order(self):
+		broken = {'capabilities': ('title',), 'fields': {'title': lambda i: 1 / 0}}
+		result = list_sort.apply(self.data, {'field': 'title', 'direction': 'asc'}, broken)
+		self.assertEqual(['Banana', 'The Apple', 'cherry'], self._titles(result))
+
+	def test_default_field_returns_new_list_not_same_object(self):
+		result = list_sort.apply(self.data, {'field': 'default', 'direction': 'asc'}, ADAPTER)
+		self.assertIsNot(self.data, result)
+
+	def test_sorting_path_returns_new_list_not_same_object(self):
+		result = list_sort.apply(self.data, {'field': 'title', 'direction': 'asc'}, ADAPTER)
+		self.assertIsNot(self.data, result)
+
+	def test_mutating_result_does_not_affect_input_on_aliasing_path(self):
+		original = list(self.data)
+		result = list_sort.apply(self.data, {'field': 'default', 'direction': 'asc'}, ADAPTER)
+		result.append({'title': 'Zebra', 'added': '2024-01-04', 'released': None, 'rating': 1.0})
+		result.sort(key=lambda i: i['title'])
+		self.assertEqual(original, self.data)
+
+	def test_mutating_result_does_not_affect_input_on_sorting_path(self):
+		original = list(self.data)
+		result = list_sort.apply(self.data, {'field': 'title', 'direction': 'asc'}, ADAPTER)
+		result.append({'title': 'Zebra', 'added': '2024-01-04', 'released': None, 'rating': 1.0})
+		result.sort(key=lambda i: i['title'])
+		self.assertEqual(original, self.data)
+
+
+if __name__ == '__main__':
+	unittest.main()

--- a/tests/test_list_sort_migration.py
+++ b/tests/test_list_sort_migration.py
@@ -1,0 +1,857 @@
+import importlib.util
+import sqlite3
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+LIST_SORT_PATH = ROOT / 'plugin.video.redlight' / 'resources' / 'lib' / 'modules' / 'list_sort.py'
+
+
+def _install_stubs():
+	caches = types.ModuleType('caches')
+	caches.__path__ = []
+	list_sort_cache = types.ModuleType('caches.list_sort_cache')
+	list_sort_cache.scope_key = lambda list_key, media_type=None: list_key
+	list_sort_cache.normalize_media_type = lambda m: ''
+	list_sort_cache.get_override = lambda scope: ''
+	list_sort_cache.set_override = lambda scope, spec: True
+	settings_cache = types.ModuleType('caches.settings_cache')
+	settings_cache.get_setting = lambda setting_id, fallback='': fallback
+	sys.modules['caches'] = caches
+	sys.modules['caches.list_sort_cache'] = list_sort_cache
+	sys.modules['caches.settings_cache'] = settings_cache
+
+
+def _load_list_sort_module():
+	_install_stubs()
+	spec = importlib.util.spec_from_file_location('list_sort_migration_under_test', LIST_SORT_PATH)
+	module = importlib.util.module_from_spec(spec)
+	spec.loader.exec_module(module)
+	return module
+
+
+list_sort = _load_list_sort_module()
+
+
+class LegacyCodeTranslationTests(unittest.TestCase):
+	def test_all_sync_codes(self):
+		expected = {'0': 'title:asc', '1': 'date_added:desc', '2': 'release_date:desc', '3': 'date_added:asc', '4': 'release_date:asc'}
+		for code, spec_string in expected.items():
+			self.assertEqual(spec_string, list_sort.LEGACY_SYNC_CODES[code], 'code %s' % code)
+
+	def test_all_tmdb_codes(self):
+		expected = {'0': 'title:asc', '1': 'release_date:asc', '2': 'release_date:desc', '3': 'random:asc', '4': 'default:asc'}
+		for code, spec_string in expected.items():
+			self.assertEqual(spec_string, list_sort.LEGACY_TMDB_CODES[code], 'code %s' % code)
+
+	def test_all_mdblist_codes(self):
+		# apis/mdblist_api.py:574-577 and :585-588 are three-way: 2 -> release date/year desc,
+		# 1 -> watchlist_at/collected_at desc, everything else (0, 3, 4) -> title.
+		expected = {'0': 'title:asc', '1': 'date_added:desc', '2': 'release_date:desc', '3': 'title:asc', '4': 'title:asc'}
+		for code, spec_string in expected.items():
+			self.assertEqual(spec_string, list_sort.LEGACY_MDBLIST_CODES[code], 'code %s' % code)
+
+
+class MigrationTests(unittest.TestCase):
+	def test_watchlist_seeds_both_defaults(self):
+		result = list_sort.migrate_legacy_sort_settings({'sort.watchlist': '1'})
+		self.assertEqual('date_added:desc', result['defaults']['sort.default.movies'])
+		self.assertEqual('date_added:desc', result['defaults']['sort.default.shows'])
+
+	def test_absent_settings_use_the_old_getters_own_fallbacks(self):
+		# An absent row is not "no preference": lists_sort_order fell back to code 0 (title) and
+		# tmdblists_sort_order to code 4 (provider order), and lists were ordered by exactly that.
+		result = list_sort.migrate_legacy_sort_settings({})
+		self.assertEqual('title:asc', result['defaults']['sort.default.movies'])
+		self.assertEqual('title:asc', result['defaults']['sort.default.shows'])
+		for scope in ('mdblist.watchlist:movies', 'mdblist.watchlist:shows',
+				'mdblist.collection:movies', 'mdblist.collection:shows'):
+			self.assertEqual('title:asc', result['overrides'][scope], scope)
+		self.assertEqual('default:asc', result['overrides']['tmdb:watchlist'])
+		self.assertEqual('default:asc', result['overrides']['tmdb:favorites'])
+		# Trakt collection and Simkl matched the title baseline, so they need no override.
+		self.assertNotIn('trakt.collection:movies', result['overrides'])
+		self.assertNotIn('simkl:movies', result['overrides'])
+
+	def test_blank_stored_value_is_treated_as_absent(self):
+		result = list_sort.migrate_legacy_sort_settings({'sort.watchlist': '', 'tmdbsort.favorites': ''})
+		self.assertEqual('title:asc', result['defaults']['sort.default.movies'])
+		self.assertEqual('default:asc', result['overrides']['tmdb:favorites'])
+
+	def test_absent_collection_keeps_title_not_the_watchlist_default(self):
+		# The regression: with only sort.watchlist stored, the collection scopes used to inherit the
+		# new global default seeded from it, where the old code gave them title.
+		result = list_sort.migrate_legacy_sort_settings({'sort.watchlist': '1'})
+		self.assertEqual('date_added:desc', result['defaults']['sort.default.movies'])
+		self.assertEqual('title:asc', result['overrides']['trakt.collection:movies'])
+		self.assertEqual('title:asc', result['overrides']['trakt.collection:shows'])
+		self.assertEqual('title:asc', result['overrides']['simkl:movies'])
+		self.assertEqual('title:asc', result['overrides']['simkl:shows'])
+		self.assertEqual('default:asc', result['overrides']['tmdb:watchlist'])
+
+	def test_matching_collection_produces_no_trakt_override(self):
+		result = list_sort.migrate_legacy_sort_settings({'sort.watchlist': '2', 'sort.collection': '2'})
+		self.assertNotIn('trakt.collection:movies', result['overrides'])
+		self.assertNotIn('trakt.collection:shows', result['overrides'])
+
+	def test_differing_collection_overrides_trakt_only(self):
+		# MDBList is no longer written from the Trakt collection branch; it has its own table.
+		# Code 3 is deliberate: LEGACY_SYNC_CODES['3'] is date_added:asc but LEGACY_MDBLIST_CODES['3']
+		# is title:asc, so this pins the separation. A code where the two tables agree (e.g. '1')
+		# would pass whichever branch produced the value.
+		result = list_sort.migrate_legacy_sort_settings({'sort.watchlist': '0', 'sort.collection': '3'})
+		self.assertEqual('date_added:asc', result['overrides']['trakt.collection:movies'])
+		self.assertEqual('date_added:asc', result['overrides']['trakt.collection:shows'])
+		self.assertEqual('title:asc', result['overrides']['mdblist.collection:movies'])
+		self.assertEqual('title:asc', result['overrides']['mdblist.collection:shows'])
+
+	def test_differing_simkl_overrides_both_media_types(self):
+		result = list_sort.migrate_legacy_sort_settings({'sort.watchlist': '0', 'sort.simkl': '4'})
+		self.assertEqual('release_date:asc', result['overrides']['simkl:movies'])
+		self.assertEqual('release_date:asc', result['overrides']['simkl:shows'])
+
+	def test_mdblist_scopes_are_always_written_explicitly(self):
+		result = list_sort.migrate_legacy_sort_settings({'sort.watchlist': '1', 'sort.collection': '1'})
+		for scope in ('mdblist.watchlist:movies', 'mdblist.watchlist:shows',
+				'mdblist.collection:movies', 'mdblist.collection:shows'):
+			self.assertEqual('date_added:desc', result['overrides'][scope], scope)
+
+	def test_mdblist_pins_title_for_codes_it_never_honoured(self):
+		# Code 3 is date-added-ascending on Trakt but title on MDBList. The global default is
+		# seeded from sort.watchlist, so without an explicit override MDBList would flip.
+		for code in ('0', '3', '4'):
+			result = list_sort.migrate_legacy_sort_settings({'sort.watchlist': code, 'sort.collection': code})
+			for scope in ('mdblist.watchlist:movies', 'mdblist.watchlist:shows',
+					'mdblist.collection:movies', 'mdblist.collection:shows'):
+				self.assertEqual('title:asc', result['overrides'][scope], '%s code %s' % (scope, code))
+
+	def test_mdblist_watchlist_and_collection_translate_independently(self):
+		result = list_sort.migrate_legacy_sort_settings({'sort.watchlist': '3', 'sort.collection': '2'})
+		self.assertEqual('title:asc', result['overrides']['mdblist.watchlist:movies'])
+		self.assertEqual('title:asc', result['overrides']['mdblist.watchlist:shows'])
+		self.assertEqual('release_date:desc', result['overrides']['mdblist.collection:movies'])
+		self.assertEqual('release_date:desc', result['overrides']['mdblist.collection:shows'])
+
+	def test_mdblist_ordering_preserved_when_legacy_setting_absent(self):
+		# An absent sort.collection meant title (the old getter's '0' fallback). Leaving the scope
+		# unwritten would let it inherit the global default seeded from sort.watchlist instead.
+		result = list_sort.migrate_legacy_sort_settings({'sort.watchlist': '1'})
+		self.assertEqual('date_added:desc', result['overrides']['mdblist.watchlist:movies'])
+		self.assertEqual('title:asc', result['overrides']['mdblist.collection:movies'])
+		self.assertEqual('title:asc', result['overrides']['mdblist.collection:shows'])
+
+	def test_unknown_mdblist_code_writes_no_override(self):
+		result = list_sort.migrate_legacy_sort_settings({'sort.watchlist': '99'})
+		self.assertNotIn('mdblist.watchlist:movies', result['overrides'])
+
+	def test_tmdb_settings_always_become_overrides(self):
+		result = list_sort.migrate_legacy_sort_settings({'tmdbsort.watchlist': '4', 'tmdbsort.favorites': '2'})
+		self.assertEqual('default:asc', result['overrides']['tmdb:watchlist'])
+		self.assertEqual('release_date:desc', result['overrides']['tmdb:favorites'])
+
+	def test_unknown_code_is_ignored(self):
+		result = list_sort.migrate_legacy_sort_settings({'sort.watchlist': '99'})
+		self.assertEqual({}, result['defaults'])
+
+
+class LegacyStoreTranslationTests(unittest.TestCase):
+	def test_trakt_custom_sort_keys_remap(self):
+		cases = {
+			('added', 'desc'): 'date_added:desc',
+			('popularity', 'asc'): 'votes:asc',
+			('percentage', 'desc'): 'rating:desc',
+			('released', 'asc'): 'release_date:asc',
+			('rank', 'asc'): 'rank:asc',
+			('runtime', 'desc'): 'runtime:desc',
+			('title', 'desc'): 'title:desc',
+			('random', 'asc'): 'random:asc',
+			('default', 'asc'): 'default:asc',
+		}
+		for (sort_by, sort_how), expected in cases.items():
+			self.assertEqual(expected, list_sort.translate_trakt_custom_sort(sort_by, sort_how), sort_by)
+
+	def test_unknown_trakt_key_returns_empty(self):
+		self.assertEqual('', list_sort.translate_trakt_custom_sort('nonsense', 'asc'))
+
+	def test_personal_codes(self):
+		expected = {'0': 'title:asc', '1': 'date_added:asc', '2': 'date_added:desc', '3': 'release_date:asc',
+			'4': 'release_date:desc', '5': 'random:asc', 'None': 'default:asc', '': 'title:asc'}
+		for code, spec_string in expected.items():
+			self.assertEqual(spec_string, list_sort.LEGACY_PERSONAL_CODES[code], 'code %s' % code)
+
+
+class RunMigrationTests(unittest.TestCase):
+	# run_sort_migration() does a lazy `from caches.list_sort_cache import set_override`
+	# inside the function body, so it resolves whatever is in sys.modules at call time —
+	# not what was there when this file's module-level list_sort was built. Other test
+	# files in this suite install their own competing 'caches.list_sort_cache' stub at
+	# import time (e.g. test_list_sort_resolve.py's stub has no set_override), and
+	# collection order can leave that stub in sys.modules by the time these tests run.
+	# Reinstall our own stubs here so these tests are independent of collection order.
+	def setUp(self):
+		self._original_sys_modules = {}
+		for key in ('caches', 'caches.list_sort_cache', 'caches.settings_cache'):
+			if key in sys.modules:
+				self._original_sys_modules[key] = sys.modules[key]
+		_install_stubs()
+
+	def tearDown(self):
+		for key in ('caches', 'caches.list_sort_cache', 'caches.settings_cache'):
+			if key in self._original_sys_modules:
+				sys.modules[key] = self._original_sys_modules[key]
+			else:
+				sys.modules.pop(key, None)
+
+	def test_writes_defaults_and_overrides(self):
+		written_settings, written_overrides = {}, {}
+		list_sort_cache = sys.modules['caches.list_sort_cache']
+		list_sort_cache.set_override = lambda scope, spec: written_overrides.__setitem__(scope, spec) or True
+		changed = list_sort.run_sort_migration({'sort.watchlist': '1', 'sort.collection': '2'},
+			lambda setting_id, value: written_settings.__setitem__(setting_id, value))
+		self.assertTrue(changed)
+		self.assertEqual('date_added:desc', written_settings['sort.default.movies'])
+		self.assertEqual('Date Added (descending)', written_settings['sort.default.movies_name'])
+		self.assertEqual('release_date:desc', written_overrides['trakt.collection:movies'])
+
+	def test_absent_legacy_settings_still_pin_the_documented_fallbacks(self):
+		# There is no "nothing to migrate" case any more: a profile with no legacy rows was still
+		# being ordered by the old getters' fallbacks, and those have to be written down.
+		written_settings, written_overrides = {}, {}
+		list_sort_cache = sys.modules['caches.list_sort_cache']
+		list_sort_cache.set_override = lambda scope, spec: written_overrides.__setitem__(scope, spec) or True
+		changed = list_sort.run_sort_migration({}, lambda setting_id, value: written_settings.__setitem__(setting_id, value))
+		self.assertTrue(changed)
+		self.assertEqual('title:asc', written_settings['sort.default.movies'])
+		self.assertEqual('default:asc', written_overrides['tmdb:watchlist'])
+		self.assertEqual('title:asc', written_overrides['mdblist.watchlist:movies'])
+
+	def test_failed_override_raises_instead_of_reporting_success(self):
+		# set_override() swallows its own exceptions and returns False, so an unwritable store
+		# must not be reported as a clean migration.
+		list_sort_cache = sys.modules['caches.list_sort_cache']
+		list_sort_cache.set_override = lambda scope, spec: False
+		with self.assertRaises(list_sort.SortMigrationError):
+			list_sort.run_sort_migration({'sort.watchlist': '1'}, lambda setting_id, value: None)
+
+	def test_every_override_is_attempted_before_raising(self):
+		attempted = []
+		list_sort_cache = sys.modules['caches.list_sort_cache']
+		list_sort_cache.set_override = lambda scope, spec: attempted.append(scope) or (scope != 'simkl:movies')
+		with self.assertRaises(list_sort.SortMigrationError):
+			list_sort.run_sort_migration({'sort.watchlist': '1', 'sort.simkl': '2'}, lambda setting_id, value: None)
+		self.assertIn('simkl:shows', attempted)
+		self.assertIn('mdblist.watchlist:movies', attempted)
+
+
+class SentinelTests(unittest.TestCase):
+	def setUp(self):
+		self._original_sys_modules = {}
+		for key in ('modules', 'modules.kodi_utils', 'modules.settings', 'caches', 'caches.base_cache', 'caches.settings_cache'):
+			if key in sys.modules:
+				self._original_sys_modules[key] = sys.modules[key]
+
+	def tearDown(self):
+		for key in ('modules', 'modules.kodi_utils', 'modules.settings', 'caches', 'caches.base_cache', 'caches.settings_cache'):
+			if key in self._original_sys_modules:
+				sys.modules[key] = self._original_sys_modules[key]
+			else:
+				sys.modules.pop(key, None)
+
+	def test_sentinel_declared_in_default_settings(self):
+		from test_settings_cache_calendar_migration import _load_settings_cache_module
+		module = _load_settings_cache_module()
+		ids = [s['setting_id'] for s in module.default_settings()]
+		self.assertIn('migration.unified_list_sort', ids)
+
+	def test_new_sort_defaults_declared(self):
+		from test_settings_cache_calendar_migration import _load_settings_cache_module
+		module = _load_settings_cache_module()
+		ids = [s['setting_id'] for s in module.default_settings()]
+		for setting_id in ('sort.default.movies', 'sort.default.movies_name', 'sort.default.shows', 'sort.default.shows_name'):
+			self.assertIn(setting_id, ids)
+
+	def test_old_sort_ids_removed(self):
+		from test_settings_cache_calendar_migration import _load_settings_cache_module
+		module = _load_settings_cache_module()
+		ids = [s['setting_id'] for s in module.default_settings()]
+		for setting_id in ('sort.watchlist', 'sort.collection', 'sort.simkl', 'tmdbsort.watchlist', 'tmdbsort.favorites'):
+			self.assertNotIn(setting_id, ids)
+
+	def test_progress_and_watched_sorts_survive(self):
+		from test_settings_cache_calendar_migration import _load_settings_cache_module
+		module = _load_settings_cache_module()
+		ids = [s['setting_id'] for s in module.default_settings()]
+		self.assertIn('sort.progress', ids)
+		self.assertIn('sort.watched', ids)
+
+
+class SettingsDbEmptinessTests(unittest.TestCase):
+	"""is_empty_strict() is the only thing separating "fresh install" from "database unavailable".
+
+	Run against real sqlite, because the distinction that matters is which sqlite outcomes count as
+	empty: a missing file and a missing table are genuinely empty, a locked database is not, and
+	get_all() renders all three as {}.
+	"""
+	_KEYS = ('modules', 'modules.kodi_utils', 'modules.settings', 'caches', 'caches.base_cache')
+
+	def setUp(self):
+		self._original_sys_modules = dict((k, sys.modules[k]) for k in self._KEYS if k in sys.modules)
+		from test_settings_cache_calendar_migration import _load_settings_cache_module
+		self.module = _load_settings_cache_module()
+
+	def tearDown(self):
+		for key in self._KEYS:
+			if key in self._original_sys_modules: sys.modules[key] = self._original_sys_modules[key]
+			else: sys.modules.pop(key, None)
+
+	def _store(self, exists, connection):
+		self.module.kodi_utils.path_exists = lambda path: exists
+		self.module.connect_database = lambda name: connection
+		return self.module.settings_cache
+
+	def test_a_missing_database_file_is_empty(self):
+		self.assertTrue(self._store(False, None).is_empty_strict())
+
+	def test_a_missing_table_is_empty(self):
+		connection = sqlite3.connect(':memory:')
+		self.assertTrue(self._store(True, connection).is_empty_strict())
+
+	def test_an_empty_table_is_empty(self):
+		connection = sqlite3.connect(':memory:')
+		connection.execute('CREATE TABLE settings (setting_id text, setting_type text, setting_default text, setting_value text)')
+		self.assertTrue(self._store(True, connection).is_empty_strict())
+
+	def test_a_populated_table_is_not_empty(self):
+		connection = sqlite3.connect(':memory:')
+		connection.execute('CREATE TABLE settings (setting_id text, setting_type text, setting_default text, setting_value text)')
+		connection.execute("INSERT INTO settings VALUES ('sort.watchlist', 'action', '0', '3')")
+		self.assertFalse(self._store(True, connection).is_empty_strict())
+
+	def test_an_unreadable_database_raises_instead_of_reporting_empty(self):
+		"""The whole point. get_all() answers {} here and cannot be told apart from a fresh install."""
+		class _Locked:
+			@staticmethod
+			def execute(*args):
+				raise sqlite3.OperationalError('database is locked')
+		with self.assertRaises(sqlite3.OperationalError):
+			self._store(True, _Locked).is_empty_strict()
+
+	def test_a_corrupt_database_raises_instead_of_reporting_empty(self):
+		class _Corrupt:
+			@staticmethod
+			def execute(*args):
+				raise sqlite3.DatabaseError('database disk image is malformed')
+		with self.assertRaises(sqlite3.DatabaseError):
+			self._store(True, _Corrupt).is_empty_strict()
+
+
+class SyncSettingsMigrationTests(unittest.TestCase):
+	"""End-to-end: run the real sync_settings() over a fake profile holding legacy sort settings.
+
+	The primary guard here is the obsolete purge deferral: sync_settings() would otherwise delete
+	sort.watchlist and friends as obsolete ids before the migration block runs, so a failed run
+	would destroy the only copy of the user's per-list orderings. These tests pin that deferral.
+
+	The pre-purge legacy_sort_settings snapshot is secondary and deliberately unpinned - with the
+	deferral in place, passing currentsettings directly leaves every test here green. It is kept as
+	belt-and-braces for the day the deferral is removed, not because anything covers it.
+	"""
+	_KEYS = ('modules', 'modules.kodi_utils', 'modules.settings', 'modules.list_sort',
+		'caches', 'caches.base_cache', 'caches.settings_cache', 'caches.list_sort_cache',
+		'caches.trakt_cache', 'caches.tmdb_lists', 'caches.personal_lists_cache')
+
+	def setUp(self):
+		self._original_sys_modules = {}
+		for key in self._KEYS:
+			if key in sys.modules:
+				self._original_sys_modules[key] = sys.modules[key]
+		from test_settings_cache_calendar_migration import _load_settings_cache_module
+		self.module = _load_settings_cache_module()
+		# _load_settings_cache_module() replaces sys.modules['caches'], so install the modules the
+		# lazy imports inside the migration resolve at call time afterwards, not before.
+		self.overrides = {}
+		self.override_result = True
+		self.failing_scopes = ()
+		self.trakt_rows, self.personal_rows, self.tmdb_rows = {}, {}, {}
+		self.stores_raise = False
+		self.failing_stores = set()
+		list_sort_cache = types.ModuleType('caches.list_sort_cache')
+		list_sort_cache.set_override = self._set_override
+		sys.modules['caches.list_sort_cache'] = list_sort_cache
+		sys.modules['modules.list_sort'] = list_sort
+		# The three legacy per-list stores. Without them the store migration would fail on an
+		# ImportError on every run here, which is exactly the condition these tests pin.
+		#
+		# Each store is stubbed twice, exactly as production has it: a _strict getter that raises when
+		# the store is unreadable, and - for Trakt and TMDb - the swallowing sibling the UI calls,
+		# which answers {} no matter what. The swallowing stub deliberately never raises, so a
+		# migration that reached for it would see "nothing stored" and set the sentinel; that is what
+		# test_unreadable_legacy_store_leaves_the_sentinel_unset detects.
+		trakt_cache = types.ModuleType('caches.trakt_cache')
+		trakt_cache.get_all_lists_custom_sort_strict = lambda: self._store_rows('trakt', self.trakt_rows)
+		trakt_cache.get_all_lists_custom_sort = lambda: self._swallowed_rows('trakt', self.trakt_rows)
+		sys.modules['caches.trakt_cache'] = trakt_cache
+		tmdb_lists = types.ModuleType('caches.tmdb_lists')
+		tmdb_lists.tmdb_lists_cache = types.SimpleNamespace(
+			get_sort_orders_strict=lambda: self._store_rows('tmdb', self.tmdb_rows),
+			get_sort_orders=lambda: self._swallowed_rows('tmdb', self.tmdb_rows))
+		sys.modules['caches.tmdb_lists'] = tmdb_lists
+		personal_lists_cache = types.ModuleType('caches.personal_lists_cache')
+		personal_lists_cache.personal_lists_cache = types.SimpleNamespace(
+			get_all_sort_orders=lambda: self._store_rows('personal', self.personal_rows))
+		sys.modules['caches.personal_lists_cache'] = personal_lists_cache
+
+	def _unreadable(self, name):
+		return self.stores_raise or name in self.failing_stores
+
+	def _store_rows(self, name, rows):
+		if self._unreadable(name): raise RuntimeError('legacy store unavailable')
+		return dict(rows)
+
+	def _swallowed_rows(self, name, rows):
+		"""What the UI-facing getters do: an unreadable store is indistinguishable from an empty one."""
+		if self._unreadable(name): return {}
+		return dict(rows)
+
+	def tearDown(self):
+		for key in self._KEYS:
+			if key in self._original_sys_modules:
+				sys.modules[key] = self._original_sys_modules[key]
+			else:
+				sys.modules.pop(key, None)
+
+	def _set_override(self, scope, spec_string):
+		if not self.override_result or scope in self.failing_scopes: return False
+		self.overrides[scope] = spec_string
+		return True
+
+	def _sync(self, initial, db_readable=True):
+		from test_settings_cache_calendar_migration import FakeSettingsCache
+		cache = FakeSettingsCache(initial, db_readable=db_readable)
+		self.module.settings_cache = cache
+		return self._resync(cache)
+
+	def _resync(self, cache):
+		self.module.settings_cache = cache
+		result = self.module.sync_settings({'silent': 'true', 'load_properties': 'false', 'force': 'true'})
+		self.assertEqual('synced', result)
+		return cache
+
+	def test_an_unreadable_settings_db_does_not_seed_the_sentinel(self):
+		"""get_all() swallows a locked database and answers {}, which reads as a fresh install. Seeding
+		the sentinel there is permanent: the next healthy sync sees 'true', never runs the migration,
+		and the obsolete purge then deletes the five legacy ids and the user's only stored orderings
+		with them. The three legacy per-list stores would never be read by anything again."""
+		cache = self._sync({'sort.watchlist': '3', 'tmdbsort.watchlist': '2'}, db_readable=False)
+		self.assertNotEqual('true', cache.data.get('migration.unified_list_sort'))
+		self.assertEqual({}, self.overrides)
+
+		# The very next healthy sync must still migrate, with the legacy ids intact.
+		cache.db_readable = True
+		self._resync(cache)
+		self.assertEqual('true', cache.data['migration.unified_list_sort'])
+		self.assertEqual('date_added:asc', cache.data['sort.default.movies'])
+		self.assertEqual('release_date:desc', self.overrides['tmdb:watchlist'])
+
+	def test_an_unreadable_settings_db_on_an_empty_profile_still_defers(self):
+		"""Nothing distinguishes this from the case above at the moment sync_settings runs - which is
+		the whole point. Deferring costs one extra sync; seeding costs the user's preferences."""
+		cache = self._sync({}, db_readable=False)
+		self.assertNotEqual('true', cache.data.get('migration.unified_list_sort'))
+
+	def test_a_genuinely_empty_settings_db_seeds_the_sentinel(self):
+		"""The other half: is_empty_strict() answering True without raising is a real fresh install,
+		and the sentinel has to be seeded or the migration writes six overrides nobody asked for."""
+		cache = self._sync({})
+		self.assertEqual('true', cache.data['migration.unified_list_sort'])
+		self.assertEqual({}, self.overrides)
+
+	def test_legacy_values_migrate_then_purge_on_the_following_sync(self):
+		cache = self._sync({
+			'sort.watchlist': '3',
+			'sort.collection': '2',
+			'sort.simkl': '4',
+			'tmdbsort.watchlist': '4',
+		})
+
+		# Fails if the purge deferral is removed: sort.watchlist would be deleted as an obsolete id
+		# before the migration block runs, so the defaults would never be written. The pre-purge
+		# snapshot is not what is being pinned here - it is redundant while the deferral holds.
+		self.assertEqual('date_added:asc', cache.data['sort.default.movies'])
+		self.assertEqual('date_added:asc', cache.data['sort.default.shows'])
+		self.assertEqual('Date Added (ascending)', cache.data['sort.default.movies_name'])
+		self.assertEqual('Date Added (ascending)', cache.data['sort.default.shows_name'])
+		self.assertEqual('release_date:desc', self.overrides['trakt.collection:movies'])
+		self.assertEqual('release_date:desc', self.overrides['trakt.collection:shows'])
+		self.assertEqual('release_date:asc', self.overrides['simkl:movies'])
+		self.assertEqual('release_date:asc', self.overrides['simkl:shows'])
+		self.assertEqual('default:asc', self.overrides['tmdb:watchlist'])
+		self.assertEqual('true', cache.data['migration.unified_list_sort'])
+		# The legacy ids are held back from the obsolete purge until the sentinel is set, so they
+		# are still present on the run that migrates them and only disappear on the next sync.
+		self.assertIn('sort.watchlist', cache.data)
+		self.assertIn('tmdbsort.watchlist', cache.data)
+		self.module.settings_cache = cache
+		self.assertEqual('synced', self.module.sync_settings({'silent': 'true', 'load_properties': 'false', 'force': 'true'}))
+		self.assertNotIn('sort.watchlist', cache.data)
+		self.assertNotIn('tmdbsort.watchlist', cache.data)
+
+	def test_mdblist_ordering_is_pinned_not_inherited(self):
+		# Old code 3 is date-added-ascending on Trakt but title on MDBList.
+		cache = self._sync({'sort.watchlist': '3', 'sort.collection': '3'})
+
+		self.assertEqual('date_added:asc', cache.data['sort.default.movies'])
+		for scope in ('mdblist.watchlist:movies', 'mdblist.watchlist:shows',
+				'mdblist.collection:movies', 'mdblist.collection:shows'):
+			self.assertEqual('title:asc', self.overrides[scope], scope)
+
+	def test_sentinel_not_set_when_overrides_cannot_persist(self):
+		self.override_result = False
+		cache = self._sync({'sort.watchlist': '1', 'sort.collection': '2'})
+
+		self.assertNotEqual('true', cache.data.get('migration.unified_list_sort'))
+		self.assertEqual('false', cache.data['migration.unified_list_sort'])
+
+	def test_failed_migration_is_retried_for_real_on_the_next_sync(self):
+		# The retry is only real if the legacy ids survive the failed pass. Without the purge
+		# deferral they are deleted on the first sync, the second sync migrates an empty snapshot
+		# and flips the sentinel - the door closes instead of reopening, and every per-list
+		# override is lost permanently.
+		self.override_result = False
+		cache = self._sync({'sort.watchlist': '1', 'sort.collection': '2', 'tmdbsort.watchlist': '3'})
+		self.assertEqual('false', cache.data['migration.unified_list_sort'])
+		self.assertEqual({}, self.overrides)
+		self.assertIn('sort.collection', cache.data)
+
+		self.override_result = True
+		self.module.settings_cache = cache
+		self.assertEqual('synced', self.module.sync_settings({'silent': 'true', 'load_properties': 'false', 'force': 'true'}))
+
+		self.assertEqual('true', cache.data['migration.unified_list_sort'])
+		self.assertEqual('release_date:desc', self.overrides['trakt.collection:movies'])
+		self.assertEqual('release_date:desc', self.overrides['trakt.collection:shows'])
+		self.assertEqual('release_date:desc', self.overrides['mdblist.collection:movies'])
+		self.assertEqual('date_added:desc', self.overrides['mdblist.watchlist:movies'])
+		self.assertEqual('random:asc', self.overrides['tmdb:watchlist'])
+		self.assertEqual('date_added:desc', cache.data['sort.default.movies'])
+
+	def test_profile_with_no_legacy_rows_pins_the_old_fallbacks(self):
+		cache = self._sync({'general.check_settings_file': 'true'})
+
+		self.assertEqual('true', cache.data['migration.unified_list_sort'])
+		self.assertEqual('title:asc', cache.data['sort.default.movies'])
+		self.assertEqual('title:asc', cache.data['sort.default.shows'])
+		self.assertEqual('title:asc', self.overrides['mdblist.watchlist:movies'])
+		self.assertEqual('default:asc', self.overrides['tmdb:watchlist'])
+		self.assertEqual('default:asc', self.overrides['tmdb:favorites'])
+		self.assertNotIn('trakt.collection:movies', self.overrides)
+		self.assertNotIn('simkl:movies', self.overrides)
+
+	def test_fresh_install_writes_no_overrides_at_all(self):
+		# A brand-new profile has nothing to migrate, but the migration reads absent legacy ids as
+		# their old fallbacks and would pin six overrides for a user who never touched a sort setting.
+		# The sentinel is seeded 'true' on the fresh-install pass so the block never runs here.
+		cache = self._sync({})
+		self.assertEqual('true', cache.data['migration.unified_list_sort'])
+		self.assertEqual({}, self.overrides)
+
+		self.module.settings_cache = cache
+		self.assertEqual('synced', self.module.sync_settings({'silent': 'true', 'load_properties': 'false', 'force': 'true'}))
+		self.assertEqual('true', cache.data['migration.unified_list_sort'])
+		self.assertEqual({}, self.overrides)
+
+	def test_legacy_store_rows_migrate_alongside_the_settings(self):
+		self.trakt_rows = {'12345': {'sort_by': 'rank', 'sort_how': 'asc'}}
+		self.personal_rows = {('Faves', 'jo'): '2'}
+		self.tmdb_rows = {8675309: 'None'}
+		cache = self._sync({'sort.watchlist': '1'})
+
+		self.assertEqual('rank:asc', self.overrides['trakt.list:12345'])
+		self.assertEqual('date_added:desc', self.overrides['personal:Faves|jo'])
+		self.assertEqual('default:asc', self.overrides['tmdb:8675309'])
+		self.assertEqual('true', cache.data['migration.unified_list_sort'])
+
+	def test_unreadable_legacy_store_leaves_the_sentinel_unset(self):
+		# The sentinel is the one-way door: writing it on a run that saved nothing discards every
+		# per-list Trakt, personal and TMDb preference, because the legacy ids are purged next sync.
+		# Only the _strict getters raise here; the swallowing siblings answer {} exactly as they do
+		# in production, so this also fails if the migration reads the store through those.
+		self.stores_raise = True
+		cache = self._sync({'sort.watchlist': '1'})
+
+		self.assertEqual('false', cache.data['migration.unified_list_sort'])
+
+	def test_any_single_unreadable_store_leaves_the_sentinel_unset(self):
+		# One locked database out of three is enough: the rows in it are unrecoverable once the
+		# sentinel is set. Pinned per store because each is read through a different getter and a
+		# swallowing one would leave that store's preferences silently dropped.
+		for store in ('trakt', 'personal', 'tmdb'):
+			with self.subTest(store=store):
+				self.overrides = {}
+				self.failing_stores = {store}
+				self.trakt_rows = {'12345': {'sort_by': 'rank', 'sort_how': 'asc'}}
+				self.personal_rows = {('Faves', 'jo'): '2'}
+				self.tmdb_rows = {8675309: '2'}
+				cache = self._sync({'sort.watchlist': '1'})
+				self.assertEqual('false', cache.data['migration.unified_list_sort'])
+
+	def test_unreadable_store_is_not_mistaken_for_an_empty_one(self):
+		# The regression this guards: the store getters used to end in `except: return {}`, so a
+		# locked database produced an empty translation, no failure, and a permanent sentinel.
+		self.stores_raise = True
+		cache = self._sync({'sort.watchlist': '1'})
+		self.assertEqual('false', cache.data['migration.unified_list_sort'])
+
+		# Same profile, same empty result - but the stores really are empty this time.
+		self.stores_raise = False
+		self.module.settings_cache = cache
+		self.assertEqual('synced', self.module.sync_settings({'silent': 'true', 'load_properties': 'false', 'force': 'true'}))
+		self.assertEqual('true', cache.data['migration.unified_list_sort'])
+
+	def test_unpersisted_store_override_leaves_the_sentinel_unset(self):
+		# set_override() swallows its own exceptions and reports False, so an ignored return value
+		# looks exactly like a clean success.
+		self.trakt_rows = {'12345': {'sort_by': 'rank', 'sort_how': 'asc'}}
+		self.failing_scopes = ('trakt.list:12345',)
+		cache = self._sync({'sort.watchlist': '1'})
+
+		self.assertEqual('false', cache.data['migration.unified_list_sort'])
+		self.assertNotIn('trakt.list:12345', self.overrides)
+
+	def test_failed_store_migration_is_retried_for_real_on_the_next_sync(self):
+		self.stores_raise = True
+		self.trakt_rows = {'12345': {'sort_by': 'rank', 'sort_how': 'asc'}}
+		cache = self._sync({'sort.watchlist': '1', 'sort.collection': '2'})
+		self.assertEqual('false', cache.data['migration.unified_list_sort'])
+		self.assertNotIn('trakt.list:12345', self.overrides)
+		self.assertIn('sort.collection', cache.data)
+
+		self.stores_raise = False
+		self.module.settings_cache = cache
+		self.assertEqual('synced', self.module.sync_settings({'silent': 'true', 'load_properties': 'false', 'force': 'true'}))
+
+		self.assertEqual('true', cache.data['migration.unified_list_sort'])
+		self.assertEqual('rank:asc', self.overrides['trakt.list:12345'])
+		self.assertEqual('release_date:desc', self.overrides['trakt.collection:movies'])
+
+	def test_migration_does_not_rerun_once_the_sentinel_is_set(self):
+		cache = self._sync({'sort.watchlist': '1', 'migration.unified_list_sort': 'true'})
+
+		self.assertEqual({}, self.overrides)
+		self.assertEqual('title:asc', cache.data['sort.default.movies'])
+
+
+class LegacyStoreGetterTests(unittest.TestCase):
+	"""The migration's three data sources, loaded for real, against a real sqlite3(':memory:')
+	database seeded from the production schema - not a fake that discards the SQL and hands back
+	fixture rows unconditionally. That would leave the SELECT column list, its column order, and
+	the LIKE filters completely unexercised, which is exactly the kind of bug this class exists to
+	catch: see e.g. test_personal_sort_order_getter_keeps_name_and_author_in_order below, which
+	fails if `SELECT name, author, sort_order` silently became `SELECT author, name, sort_order`.
+
+	The whole retry story rests on these getters distinguishing "nothing stored" from "could not
+	read". Every one of them used to end in `except: return {}`, which makes a locked database or a
+	corrupt row look exactly like an empty store - the migration then translates nothing, reports
+	success, and the sentinel is written over preferences that were never read.
+	"""
+	_KEYS = ('modules', 'modules.kodi_utils', 'caches', 'caches.base_cache')
+
+	def setUp(self):
+		self._original_sys_modules = {}
+		for key in self._KEYS:
+			if key in sys.modules: self._original_sys_modules[key] = sys.modules[key]
+		self.locked = False
+		self.conn = sqlite3.connect(':memory:')
+		modules = types.ModuleType('modules')
+		modules.__path__ = []
+		kodi_utils = types.ModuleType('modules.kodi_utils')
+		for name in ('sleep', 'confirm_dialog', 'close_all_dialog', 'notification', 'logger'):
+			setattr(kodi_utils, name, lambda *a, **k: None)
+		modules.kodi_utils = kodi_utils
+		sys.modules['modules'] = modules
+		sys.modules['modules.kodi_utils'] = kodi_utils
+
+		# Pull the real CREATE TABLE statements from the real base_cache module rather than
+		# hand-copying them, so the seeded schema cannot drift from production. Loading it here
+		# needs only the modules.kodi_utils stub just installed above.
+		real_base_cache = self._load('base_cache')
+		self._table_creators = real_base_cache.table_creators()
+
+		caches = types.ModuleType('caches')
+		caches.__path__ = []
+		base_cache = types.ModuleType('caches.base_cache')
+		base_cache.connect_database = lambda *a, **k: self._connect()
+		base_cache.get_timestamp = lambda *a, **k: 0
+		test_case = self
+
+		class _BaseCache(object):
+			def __init__(self, *args, **kwargs): pass
+			def manual_connect(self, *args, **kwargs): return test_case._connect()
+
+		base_cache.BaseCache = _BaseCache
+		sys.modules['caches'] = caches
+		sys.modules['caches.base_cache'] = base_cache
+
+	def tearDown(self):
+		self.conn.close()
+		for key in self._KEYS:
+			if key in self._original_sys_modules: sys.modules[key] = self._original_sys_modules[key]
+			else: sys.modules.pop(key, None)
+
+	def _connect(self):
+		if self.locked: raise RuntimeError('database is locked')
+		return self.conn
+
+	def _load(self, name):
+		path = ROOT / 'plugin.video.redlight' / 'resources' / 'lib' / 'caches' / ('%s.py' % name)
+		spec = importlib.util.spec_from_file_location('legacy_store_%s_under_test' % name, str(path))
+		module = importlib.util.module_from_spec(spec)
+		spec.loader.exec_module(module)
+		return module
+
+	def _create_table(self, db_name):
+		for statement in self._table_creators[db_name]: self.conn.execute(statement)
+
+	def _seed_trakt(self, rows):
+		"""rows: (id, data) tuples inserted with a real INSERT, exactly as trakt_cache.py writes them."""
+		self._create_table('trakt_db')
+		self.conn.executemany('INSERT INTO trakt_data (id, data) VALUES (?, ?)', rows)
+		self.conn.commit()
+
+	def _seed_tmdb(self, rows):
+		"""rows: (id, data) tuples inserted with a real INSERT, exactly as TMDbListsCache.set_sort_order writes them."""
+		self._create_table('tmdb_lists_db')
+		self.conn.executemany('INSERT INTO tmdb_lists (id, data, expires) VALUES (?, ?, 0)', rows)
+		self.conn.commit()
+
+	def _seed_personal(self, rows):
+		"""rows: (name, author, sort_order, description) tuples. sort_order is passed as the string
+		PersonalListsCache.make_list() would actually receive from the legacy sort-order URL
+		parameter; the personal_lists table declares that column `integer`, so SQLite's column
+		affinity converts the stored '2' to the int 2 on insert - real production behaviour that
+		migrate_legacy_stores()'s str() coercion depends on. Inserting an int here directly would
+		paper over that instead of exercising it."""
+		self._create_table('personal_lists_db')
+		for name, author, sort_order, description in rows:
+			self.conn.execute(
+				'INSERT INTO personal_lists (name, contents, total, created, sort_order, description, seen, poster, fanart, author, updated) '
+				'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+				(name, '[]', 0, '0', sort_order, description, 'false', '', '', author, '0'))
+		self.conn.commit()
+
+	def test_trakt_strict_getter_raises_on_a_locked_database(self):
+		module = self._load('trakt_cache')
+		self.locked = True
+		with self.assertRaises(Exception):
+			module.get_all_lists_custom_sort_strict()
+		# The UI-facing sibling keeps swallowing - that is why the migration may not use it.
+		self.assertEqual({}, module.get_all_lists_custom_sort())
+
+	def test_trakt_strict_getter_raises_on_a_corrupt_row(self):
+		# get_all_lists_custom_sort_strict() eval()s each row. One unparseable row must not read as
+		# an empty store: the remaining lists' sorts are still in there and are still recoverable.
+		self._seed_trakt([
+			('trakt_list_custom_sort_1', "{'list_id': '1', 'sort_by': 'rank', 'sort_how': 'asc'}"),
+			('trakt_list_custom_sort_2', 'not a dict {'),
+		])
+		module = self._load('trakt_cache')
+		with self.assertRaises(Exception):
+			module.get_all_lists_custom_sort_strict()
+		self.assertEqual({}, module.get_all_lists_custom_sort())
+
+	def test_trakt_getters_agree_on_a_readable_store(self):
+		self._seed_trakt([
+			('trakt_list_custom_sort_1', "{'list_id': '1', 'sort_by': 'rank', 'sort_how': 'asc'}"),
+		])
+		module = self._load('trakt_cache')
+		expected = {'1': {'sort_by': 'rank', 'sort_how': 'asc'}}
+		self.assertEqual(expected, module.get_all_lists_custom_sort_strict())
+		self.assertEqual(expected, module.get_all_lists_custom_sort())
+
+	def test_trakt_getter_filters_out_rows_that_are_not_custom_sorts(self):
+		# Kills the mutant that drops "WHERE id LIKE 'trakt_list_custom_sort_%'": without the
+		# filter, every row cached under trakt_data - including unrelated ones that merely happen
+		# to eval() to a dict - would be folded into the migrated result.
+		self._seed_trakt([
+			('trakt_list_custom_sort_1', "{'list_id': '1', 'sort_by': 'rank', 'sort_how': 'asc'}"),
+			('trakt_get_activity', "{'list_id': 'decoy', 'sort_by': 'title', 'sort_how': 'asc'}"),
+		])
+		module = self._load('trakt_cache')
+		expected = {'1': {'sort_by': 'rank', 'sort_how': 'asc'}}
+		self.assertEqual(expected, module.get_all_lists_custom_sort_strict())
+
+	def test_tmdb_strict_getter_raises_on_a_locked_database(self):
+		module = self._load('tmdb_lists')
+		cache = module.TMDbListsCache()
+		self.locked = True
+		with self.assertRaises(Exception):
+			cache.get_sort_orders_strict()
+		self.assertEqual({}, cache.get_sort_orders())
+
+	def test_tmdb_strict_getter_raises_on_a_malformed_row(self):
+		self._seed_tmdb([('sort_order_notanumber', '2')])
+		module = self._load('tmdb_lists')
+		cache = module.TMDbListsCache()
+		with self.assertRaises(Exception):
+			cache.get_sort_orders_strict()
+		self.assertEqual({}, cache.get_sort_orders())
+
+	def test_tmdb_getters_agree_on_a_readable_store(self):
+		self._seed_tmdb([('sort_order_8675309', '2')])
+		module = self._load('tmdb_lists')
+		cache = module.TMDbListsCache()
+		self.assertEqual({8675309: '2'}, cache.get_sort_orders_strict())
+		self.assertEqual({8675309: '2'}, cache.get_sort_orders())
+
+	def test_tmdb_getter_filters_out_rows_that_are_not_sort_orders(self):
+		# Kills the mutant that drops "WHERE id LIKE 'sort_order_%'": a stray tmdb_lists row (e.g.
+		# the cached user-lists payload) has an id with no 'sort_order_' prefix, so once the filter
+		# is gone int(id.replace('sort_order_', '')) raises on it - with the strict getter, that
+		# means the migration is stuck raising forever instead of reading the row that matters.
+		self._seed_tmdb([
+			('sort_order_8675309', '2'),
+			('get_user_lists', '[]'),
+		])
+		module = self._load('tmdb_lists')
+		cache = module.TMDbListsCache()
+		self.assertEqual({8675309: '2'}, cache.get_sort_orders_strict())
+
+	def test_personal_sort_order_getter_raises_on_a_locked_database(self):
+		# This one has no swallowing sibling: its only caller is the migration.
+		module = self._load('personal_lists_cache')
+		self.locked = True
+		with self.assertRaises(Exception):
+			module.personal_lists_cache.get_all_sort_orders()
+
+	def test_personal_sort_order_getter_reads_the_store(self):
+		self._seed_personal([('Faves', 'jo', '2', 'a description, not a sort order')])
+		module = self._load('personal_lists_cache')
+		result = module.personal_lists_cache.get_all_sort_orders()
+		# sort_order comes back as the int 2, not the string '2' that was inserted - SQLite integer
+		# affinity on the column, not something this fake should paper over.
+		self.assertEqual({('Faves', 'jo'): 2}, result)
+
+	def test_personal_sort_order_getter_keeps_name_and_author_in_order(self):
+		# Kills the mutant "SELECT name, author, sort_order" -> "SELECT author, name, sort_order":
+		# with name != author, a column swap silently inverts every migrated scope key, e.g.
+		# 'personal:jo|Faves' instead of 'personal:Faves|jo', so no migrated override is ever found.
+		self._seed_personal([('Faves', 'jo', '2', 'irrelevant')])
+		module = self._load('personal_lists_cache')
+		result = module.personal_lists_cache.get_all_sort_orders()
+		self.assertIn(('Faves', 'jo'), result)
+		self.assertNotIn(('jo', 'Faves'), result)
+
+	def test_personal_sort_order_getter_reads_sort_order_not_description(self):
+		# Kills the mutant "SELECT name, author, sort_order" -> "SELECT name, author, description":
+		# every personal list would migrate under a garbage code and be dropped as unmappable.
+		self._seed_personal([('Faves', 'jo', '2', 'this text must never be read as a sort order')])
+		module = self._load('personal_lists_cache')
+		result = module.personal_lists_cache.get_all_sort_orders()
+		self.assertEqual(2, result[('Faves', 'jo')])
+
+
+if __name__ == '__main__':
+	unittest.main()

--- a/tests/test_list_sort_resolve.py
+++ b/tests/test_list_sort_resolve.py
@@ -1,0 +1,106 @@
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+LIST_SORT_PATH = ROOT / 'plugin.video.redlight' / 'resources' / 'lib' / 'modules' / 'list_sort.py'
+
+OVERRIDES = {}
+SETTINGS = {}
+
+
+def _install_stubs():
+	caches = types.ModuleType('caches')
+	caches.__path__ = []
+	list_sort_cache = types.ModuleType('caches.list_sort_cache')
+	_media = {'movie': 'movies', 'movies': 'movies', 'show': 'shows', 'shows': 'shows', 'tvshow': 'shows'}
+
+	def scope_key(list_key, media_type=None):
+		normalized = _media.get(str(media_type).lower(), '') if media_type else ''
+		return '%s:%s' % (list_key, normalized) if normalized else list_key
+
+	list_sort_cache.scope_key = scope_key
+	list_sort_cache.normalize_media_type = lambda m: _media.get(str(m).lower(), '') if m else ''
+	list_sort_cache.get_override = lambda scope: OVERRIDES.get(scope, '')
+	settings_cache = types.ModuleType('caches.settings_cache')
+	settings_cache.get_setting = lambda setting_id, fallback='': SETTINGS.get(setting_id, fallback)
+	sys.modules['caches'] = caches
+	sys.modules['caches.list_sort_cache'] = list_sort_cache
+	sys.modules['caches.settings_cache'] = settings_cache
+
+
+def _load_list_sort_module():
+	_install_stubs()
+	spec = importlib.util.spec_from_file_location('list_sort_resolve_under_test', LIST_SORT_PATH)
+	module = importlib.util.module_from_spec(spec)
+	spec.loader.exec_module(module)
+	return module
+
+
+list_sort = _load_list_sort_module()
+
+
+class ResolveTests(unittest.TestCase):
+	def setUp(self):
+		# Other test modules in this suite install their own fake 'caches.settings_cache'
+		# into sys.modules at import time with no cleanup (e.g. test_source_utils_audio_lang.py).
+		# When the full suite runs, collection order can clobber our stub before these tests
+		# execute, since resolve() re-reads sys.modules lazily on every call. Reinstall ours
+		# here so each test sees the fakes this file installed, regardless of collection order.
+		self._original_sys_modules = {}
+		for key in ('caches', 'caches.list_sort_cache', 'caches.settings_cache'):
+			if key in sys.modules:
+				self._original_sys_modules[key] = sys.modules[key]
+		_install_stubs()
+		OVERRIDES.clear()
+		SETTINGS.clear()
+
+	def tearDown(self):
+		for key in ('caches', 'caches.list_sort_cache', 'caches.settings_cache'):
+			if key in self._original_sys_modules:
+				sys.modules[key] = self._original_sys_modules[key]
+			else:
+				sys.modules.pop(key, None)
+		OVERRIDES.clear()
+		SETTINGS.clear()
+
+	def test_falls_back_to_default_spec(self):
+		self.assertEqual(list_sort.DEFAULT_SPEC, list_sort.resolve('trakt.watchlist', 'movies'))
+
+	def test_uses_movies_default(self):
+		SETTINGS['redlight.sort.default.movies'] = 'release_date:desc'
+		self.assertEqual({'field': 'release_date', 'direction': 'desc'}, list_sort.resolve('trakt.watchlist', 'movies'))
+
+	def test_uses_shows_default(self):
+		SETTINGS['redlight.sort.default.movies'] = 'release_date:desc'
+		SETTINGS['redlight.sort.default.shows'] = 'title:asc'
+		self.assertEqual({'field': 'title', 'direction': 'asc'}, list_sort.resolve('trakt.watchlist', 'shows'))
+
+	def test_override_beats_default(self):
+		SETTINGS['redlight.sort.default.movies'] = 'release_date:desc'
+		OVERRIDES['trakt.watchlist:movies'] = 'rating:desc'
+		self.assertEqual({'field': 'rating', 'direction': 'desc'}, list_sort.resolve('trakt.watchlist', 'movies'))
+
+	def test_override_is_mediatype_specific(self):
+		OVERRIDES['trakt.watchlist:movies'] = 'rating:desc'
+		self.assertEqual(list_sort.DEFAULT_SPEC, list_sort.resolve('trakt.watchlist', 'shows'))
+
+	def test_mixed_list_uses_override_only(self):
+		OVERRIDES['trakt.list:12345'] = 'rank:asc'
+		self.assertEqual({'field': 'rank', 'direction': 'asc'}, list_sort.resolve('trakt.list:12345'))
+
+	def test_mixed_list_ignores_mediatype_defaults(self):
+		SETTINGS['redlight.sort.default.movies'] = 'release_date:desc'
+		self.assertEqual(list_sort.DEFAULT_SPEC, list_sort.resolve('trakt.list:12345'))
+
+	def test_corrupt_override_falls_through_to_default(self):
+		SETTINGS['redlight.sort.default.movies'] = 'rating:desc'
+		OVERRIDES['trakt.watchlist:movies'] = 'garbage'
+		self.assertEqual({'field': 'rating', 'direction': 'desc'}, list_sort.resolve('trakt.watchlist', 'movies'))
+
+
+if __name__ == '__main__':
+	unittest.main()

--- a/tests/test_mixed_list_sort.py
+++ b/tests/test_mixed_list_sort.py
@@ -1,0 +1,459 @@
+import ast
+import sys
+import types
+import unittest
+
+from test_trakt_sync_list_sort import ROOT, list_sort, _install_stubs, OVERRIDES, SETTINGS
+
+
+_STUBBED_MODULES = ('caches', 'caches.list_sort_cache', 'caches.settings_cache', 'modules', 'modules.settings')
+
+TRAKT_API = ROOT / 'plugin.video.redlight' / 'resources' / 'lib' / 'apis' / 'trakt_api.py'
+TMDB_LISTS = ROOT / 'plugin.video.redlight' / 'resources' / 'lib' / 'indexers' / 'tmdb_lists.py'
+PERSONAL_LISTS = ROOT / 'plugin.video.redlight' / 'resources' / 'lib' / 'indexers' / 'personal_lists.py'
+
+# Every fixture below is laid out so that the input order is not equal to any of the orders the tests
+# assert. A two-row fixture cannot do that - one of the two possible orders always coincides with the
+# input - so an implementation that ignored the spec and returned the rows untouched would pass.
+# Ranks, ratings and date_added are likewise out of title order, so title:asc and the spec under test
+# never produce the same sequence.
+TRAKT_LIST_ROWS = [
+	{'type': 'movie', 'rank': 2, 'listed_at': '2024-01-01', 'movie': {'title': 'Banana', 'released': '2001-01-01', 'rating': 5.0, 'votes': 10, 'runtime': 100}},
+	{'type': 'show', 'rank': 3, 'listed_at': '2024-02-01', 'show': {'title': 'Alpha', 'first_aired': '1999-01-01', 'rating': 9.0, 'votes': 20, 'runtime': 40}},
+	{'type': 'movie', 'rank': 1, 'listed_at': '2024-03-01', 'movie': {'title': 'Cherry', 'released': '2010-01-01', 'rating': 7.0, 'votes': 30, 'runtime': 120}},
+]
+
+TRAKT_PAYLOAD_ORDER = ['Banana', 'Alpha', 'Cherry']
+TRAKT_TITLE_ASC = ['Alpha', 'Banana', 'Cherry']
+TRAKT_RANK_ASC = ['Cherry', 'Banana', 'Alpha']
+
+# Damson carries a date_added shorter than the others on purpose: '90' sorts last numerically but
+# first descending as a string, so an extractor that dropped the int() coercion is caught here.
+PERSONAL_ROWS = [
+	{'title': 'Banana', 'date_added': '200', 'release_date': '2001-01-01'},
+	{'title': 'Alpha', 'date_added': '100', 'release_date': '1999-01-01'},
+	{'title': 'Cherry', 'date_added': '150', 'release_date': '2010-01-01'},
+	{'title': 'Damson', 'date_added': '90', 'release_date': '2005-01-01'},
+]
+
+# Damson has no release date, so release_date sorts pin the MISSING_DATE sentinel: without it the
+# comparison of None against a string raises and apply() hands back the payload order unsorted.
+#
+# The rows are deliberately NOT in original_order. tmdblist_api fetches pages 2..N through a thread
+# pool and extends the result list as each thread finishes, so the payload a TMDb list arrives in is
+# page-interleaved; original_order is the only record of what TMDb actually served. A fixture already
+# in provider order cannot tell "restored the provider order" apart from "handed the payload back
+# untouched", which is exactly how the engine shipped without a TMDb 'default' extractor.
+TMDB_ROWS = [
+	{'title': 'Cherry', 'release_date': '2010-01-01', 'original_order': 1},
+	{'title': 'Damson', 'release_date': None, 'original_order': 3},
+	{'title': 'Banana', 'release_date': '2001-01-01', 'original_order': 0},
+	{'title': 'Alpha', 'release_date': '1999-01-01', 'original_order': 2},
+]
+
+TMDB_PAYLOAD_ORDER = ['Cherry', 'Damson', 'Banana', 'Alpha']
+
+TMDB_PROVIDER_ORDER = ['Banana', 'Cherry', 'Alpha', 'Damson']
+TMDB_TITLE_ASC = ['Alpha', 'Banana', 'Cherry', 'Damson']
+TMDB_RELEASE_DESC = ['Damson', 'Cherry', 'Banana', 'Alpha']
+
+
+class _StubbedTestCase(unittest.TestCase):
+	def setUp(self):
+		# Other test modules install their own fake 'caches'/'modules' stubs into sys.modules at
+		# import time, and resolve()/sort_source() re-read sys.modules lazily on every call, so
+		# collection order could otherwise decide which stubs these tests see. Same idiom as
+		# tests/test_list_sort_resolve.py and tests/test_trakt_sync_list_sort.py.
+		self._original_sys_modules = {}
+		for key in _STUBBED_MODULES:
+			if key in sys.modules:
+				self._original_sys_modules[key] = sys.modules[key]
+		_install_stubs()
+		OVERRIDES.clear()
+		SETTINGS.clear()
+
+	def tearDown(self):
+		for key in _STUBBED_MODULES:
+			if key in self._original_sys_modules:
+				sys.modules[key] = self._original_sys_modules[key]
+			else:
+				sys.modules.pop(key, None)
+		OVERRIDES.clear()
+		SETTINGS.clear()
+
+
+class MixedListResolutionTests(_StubbedTestCase):
+	def _titles(self, rows):
+		return [i[i['type']]['title'] for i in rows]
+
+	def test_no_override_uses_default_spec(self):
+		# rating:asc would order Banana, Cherry, Alpha. A mixed list must ignore the mediatype
+		# default and land on DEFAULT_SPEC (title:asc) instead.
+		SETTINGS['redlight.sort.default.movies'] = 'rating:asc'
+		SETTINGS['redlight.sort.default.shows'] = 'rating:asc'
+		result = list_sort.sort_source(list(TRAKT_LIST_ROWS), 'trakt.list:99', None, 'trakt_list')
+		self.assertEqual(TRAKT_TITLE_ASC, self._titles(result))
+
+	def test_override_drives_trakt_list(self):
+		OVERRIDES['trakt.list:99'] = 'rank:desc'
+		result = list_sort.sort_source(list(TRAKT_LIST_ROWS), 'trakt.list:99', None, 'trakt_list')
+		self.assertEqual([3, 2, 1], [i['rank'] for i in result])
+
+	def test_override_is_scoped_to_its_own_list(self):
+		OVERRIDES['trakt.list:99'] = 'rank:desc'
+		result = list_sort.sort_source(list(TRAKT_LIST_ROWS), 'trakt.list:100', None, 'trakt_list')
+		self.assertEqual(TRAKT_TITLE_ASC, self._titles(result))
+
+	def test_trakt_list_without_override_keeps_the_payload_sort(self):
+		# The Trakt API declares the list's own ordering, and the folder URL carries it. A user who
+		# never opened "Set Custom Sort" has no override row and nothing to migrate, so the payload
+		# sort - not DEFAULT_SPEC - is the ordering that must survive the upgrade.
+		fallback = list_sort.trakt_list_fallback('rank', 'asc')
+		self.assertEqual('rank:asc', fallback)
+		result = list_sort.sort_source(list(TRAKT_LIST_ROWS), 'trakt.list:99', None, 'trakt_list', fallback=fallback)
+		self.assertEqual([1, 2, 3], [i['rank'] for i in result])
+		self.assertEqual(TRAKT_RANK_ASC, self._titles(result))
+
+	def test_trakt_payload_sort_direction_is_honoured(self):
+		result = list_sort.sort_source(list(TRAKT_LIST_ROWS), 'trakt.list:99', None, 'trakt_list',
+			fallback=list_sort.trakt_list_fallback('rank', 'desc'))
+		self.assertEqual([3, 2, 1], [i['rank'] for i in result])
+
+	def test_stored_override_beats_the_payload_sort(self):
+		OVERRIDES['trakt.list:99'] = 'title:asc'
+		result = list_sort.sort_source(list(TRAKT_LIST_ROWS), 'trakt.list:99', None, 'trakt_list',
+			fallback=list_sort.trakt_list_fallback('rank', 'asc'))
+		self.assertEqual(TRAKT_TITLE_ASC, self._titles(result))
+
+	def test_unmappable_payload_sort_leaves_the_order_untouched(self):
+		# 'my_rating', 'watched' and 'collected' have no canonical field. The old code left such a
+		# payload alone rather than retitling it, so they must resolve to the provider order.
+		for sort_by in ('my_rating', 'watched', 'collected'):
+			fallback = list_sort.trakt_list_fallback(sort_by, 'desc')
+			self.assertEqual('default:asc', fallback, sort_by)
+			result = list_sort.sort_source(list(TRAKT_LIST_ROWS), 'trakt.list:99', None, 'trakt_list', fallback=fallback)
+			self.assertEqual(TRAKT_PAYLOAD_ORDER, self._titles(result), sort_by)
+
+	def test_personal_list_override(self):
+		OVERRIDES['personal:Faves|jo'] = 'date_added:desc'
+		result = list_sort.sort_source(list(PERSONAL_ROWS), 'personal:Faves|jo', None, 'personal')
+		self.assertEqual(['Banana', 'Cherry', 'Alpha', 'Damson'], [i['title'] for i in result])
+
+	def test_personal_list_without_override_sorts_by_title(self):
+		result = list_sort.sort_source(list(PERSONAL_ROWS), 'personal:Faves|jo', None, 'personal')
+		self.assertEqual(['Alpha', 'Banana', 'Cherry', 'Damson'], [i['title'] for i in result])
+
+	def test_the_tmdb_fixture_is_not_already_in_provider_order(self):
+		# Guards the guards below: re-sort TMDB_ROWS into original_order and every provider-order
+		# assertion in this file stops distinguishing "restored" from "returned unchanged".
+		self.assertEqual(TMDB_PAYLOAD_ORDER, [i['title'] for i in TMDB_ROWS])
+		self.assertNotEqual(TMDB_PROVIDER_ORDER, TMDB_PAYLOAD_ORDER)
+		self.assertEqual(TMDB_PROVIDER_ORDER, [i['title'] for i in sorted(TMDB_ROWS, key=lambda i: i['original_order'])])
+
+	def test_tmdb_default_field_keeps_provider_order(self):
+		# 'default' for TMDb is a restore, not a no-op: the payload is page-interleaved by the
+		# thread pool that fetched it, and original_order is what TMDb served.
+		OVERRIDES['tmdb:watchlist'] = 'default:asc'
+		result = list_sort.sort_source(list(TMDB_ROWS), 'tmdb:watchlist', None, 'tmdb')
+		self.assertEqual(TMDB_PROVIDER_ORDER, [i['title'] for i in result])
+
+	def test_tmdb_rows_with_no_original_order_sort_last_without_raising(self):
+		# The old code's key was (k['original_order'] is None, k['original_order']); a row that never
+		# got stamped must not raise int-vs-None and drop the whole list back to payload order.
+		rows = [{'title': 'Nostamp', 'release_date': None}] + list(TMDB_ROWS)
+		result = list_sort.sort_source(rows, 'tmdb:watchlist', None, 'tmdb', fallback='default:asc')
+		self.assertEqual(TMDB_PROVIDER_ORDER + ['Nostamp'], [i['title'] for i in result])
+
+	def test_tmdb_release_date_override(self):
+		OVERRIDES['tmdb:8675309'] = 'release_date:desc'
+		result = list_sort.sort_source(list(TMDB_ROWS), 'tmdb:8675309', None, 'tmdb')
+		self.assertEqual(TMDB_RELEASE_DESC, [i['title'] for i in result])
+
+	def test_tmdb_list_without_override_keeps_provider_order(self):
+		# A TMDb user list nobody ever sorted has no store row and no override row. Its ordering is
+		# TMDb's own, and DEFAULT_SPEC would silently retitle it on upgrade.
+		result = list_sort.sort_source(list(TMDB_ROWS), 'tmdb:8675309', None, 'tmdb', fallback='default:asc')
+		self.assertEqual(TMDB_PROVIDER_ORDER, [i['title'] for i in result])
+
+	def test_tmdb_stored_override_beats_the_provider_order_fallback(self):
+		OVERRIDES['tmdb:8675309'] = 'title:asc'
+		result = list_sort.sort_source(list(TMDB_ROWS), 'tmdb:8675309', None, 'tmdb', fallback='default:asc')
+		self.assertEqual(TMDB_TITLE_ASC, [i['title'] for i in result])
+
+	def test_fallback_survives_a_failing_override_lookup(self):
+		# sort_source() catches resolve() raising - an unreadable override store, a broken import -
+		# and must land on the caller's fallback, not on DEFAULT_SPEC. Falling back to title:asc
+		# there is precisely the pre-fix behaviour, applied to every mixed list at once.
+		def _raise(scope): raise RuntimeError('override store unavailable')
+		sys.modules['caches.list_sort_cache'].get_override = _raise
+
+		result = list_sort.sort_source(list(TMDB_ROWS), 'tmdb:8675309', None, 'tmdb', fallback='default:asc')
+		self.assertEqual(TMDB_PROVIDER_ORDER, [i['title'] for i in result])
+
+		result = list_sort.sort_source(list(TRAKT_LIST_ROWS), 'trakt.list:99', None, 'trakt_list',
+			fallback=list_sort.trakt_list_fallback('rank', 'asc'))
+		self.assertEqual([1, 2, 3], [i['rank'] for i in result])
+
+
+class LegacyStoreMigrationTests(unittest.TestCase):
+	def test_trakt_rows_translate(self):
+		result = list_sort.migrate_legacy_stores(
+			trakt_rows={'12345': {'sort_by': 'added', 'sort_how': 'desc'}}, personal_rows={}, tmdb_rows={})
+		self.assertEqual('date_added:desc', result['trakt.list:12345'])
+
+	def test_trakt_sort_how_is_honoured(self):
+		result = list_sort.migrate_legacy_stores(
+			trakt_rows={'12345': {'sort_by': 'added', 'sort_how': 'asc'}}, personal_rows={}, tmdb_rows={})
+		self.assertEqual('date_added:asc', result['trakt.list:12345'])
+
+	def test_personal_rows_translate(self):
+		result = list_sort.migrate_legacy_stores(
+			trakt_rows={}, personal_rows={('Faves', 'jo'): '2'}, tmdb_rows={})
+		self.assertEqual('date_added:desc', result['personal:Faves|jo'])
+
+	def test_personal_code_one_is_ascending(self):
+		result = list_sort.migrate_legacy_stores(
+			trakt_rows={}, personal_rows={('Faves', 'jo'): '1'}, tmdb_rows={})
+		self.assertEqual('date_added:asc', result['personal:Faves|jo'])
+
+	def test_tmdb_rows_translate(self):
+		result = list_sort.migrate_legacy_stores(trakt_rows={}, personal_rows={}, tmdb_rows={8675309: '2'})
+		self.assertEqual('release_date:desc', result['tmdb:8675309'])
+
+	def test_tmdb_code_one_is_ascending(self):
+		result = list_sort.migrate_legacy_stores(trakt_rows={}, personal_rows={}, tmdb_rows={8675309: '1'})
+		self.assertEqual('release_date:asc', result['tmdb:8675309'])
+
+	def test_tmdb_non_string_sort_order_still_translates(self):
+		# get_sort_orders() hands back whatever the row holds; an int must not fall through the table.
+		result = list_sort.migrate_legacy_stores(trakt_rows={}, personal_rows={}, tmdb_rows={8675309: 2})
+		self.assertEqual('release_date:desc', result['tmdb:8675309'])
+
+	def test_tmdb_explicit_provider_default_choice_is_preserved(self):
+		# sort_order_tmdb_list() stores the literal string 'None' for "Default From TMDb (None)".
+		# Dropping the row would turn that explicit choice into title:asc, unrecoverably.
+		result = list_sort.migrate_legacy_stores(trakt_rows={}, personal_rows={}, tmdb_rows={8675309: 'None'})
+		self.assertEqual('default:asc', result['tmdb:8675309'])
+
+	def test_tmdb_null_and_blank_sort_orders_keep_provider_order(self):
+		result = list_sort.migrate_legacy_stores(trakt_rows={}, personal_rows={}, tmdb_rows={1: None, 2: ''})
+		self.assertEqual({'tmdb:1': 'default:asc', 'tmdb:2': 'default:asc'}, result)
+
+	def test_unmappable_rows_are_skipped(self):
+		result = list_sort.migrate_legacy_stores(
+			trakt_rows={'1': {'sort_by': 'nonsense', 'sort_how': 'asc'}}, personal_rows={('X', 'y'): '99'}, tmdb_rows={1: '99'})
+		self.assertEqual({}, result)
+
+	def test_null_personal_sort_order_becomes_provider_default(self):
+		result = list_sort.migrate_legacy_stores(trakt_rows={}, personal_rows={('Faves', 'jo'): None}, tmdb_rows={})
+		self.assertEqual('default:asc', result['personal:Faves|jo'])
+
+	def test_all_three_stores_migrate_together(self):
+		result = list_sort.migrate_legacy_stores(
+			trakt_rows={'12345': {'sort_by': 'title', 'sort_how': 'asc'}},
+			personal_rows={('Faves', 'jo'): '5'}, tmdb_rows={8675309: '4'})
+		self.assertEqual({'trakt.list:12345': 'title:asc', 'personal:Faves|jo': 'random:asc',
+			'tmdb:8675309': 'default:asc'}, result)
+
+	def test_empty_stores_translate_to_nothing(self):
+		self.assertEqual({}, list_sort.migrate_legacy_stores(None, None, None))
+
+	def test_settings_migration_cannot_reach_the_new_blank_codes(self):
+		# LEGACY_TMDB_CODES now answers 'None' and '', which _legacy_code() must never look up:
+		# it coerces a missing or blank setting to the '4' fallback first. Pinned because the two
+		# tables share LEGACY_TMDB_CODES and only the store path may see those keys.
+		for stored in (None, '', 'None'):
+			overrides = list_sort.migrate_legacy_sort_settings({'tmdbsort.watchlist': stored})['overrides']
+			self.assertEqual('default:asc', overrides['tmdb:watchlist'])
+		self.assertEqual('4', list_sort._legacy_code({'tmdbsort.watchlist': None}, 'tmdbsort.watchlist'))
+		self.assertEqual('4', list_sort._legacy_code({'tmdbsort.watchlist': ''}, 'tmdbsort.watchlist'))
+		self.assertEqual('4', list_sort._legacy_code({}, 'tmdbsort.watchlist'))
+
+
+def _sort_source_calls(path, function=None):
+	"""Every list_sort.sort_source(...) call in a module, as dicts of unparsed argument source.
+
+	Parsed from source with ast rather than imported, because both modules pull in the Kodi runtime.
+	Mirrors tests/test_simkl_mdblist_sort.py. Pass function to restrict the search to one def, which
+	is how a call site is identified without reading the very arguments under test.
+	"""
+	with open(str(path), 'r', encoding='utf-8') as f:
+		tree = ast.parse(f.read())
+	scope = tree
+	if function is not None:
+		found = [n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef) and n.name == function]
+		if len(found) != 1: raise AssertionError('expected exactly one def %s in %s' % (function, path.name))
+		scope = found[0]
+	calls = []
+	for node in ast.walk(scope):
+		if not isinstance(node, ast.Call): continue
+		func = node.func
+		if not isinstance(func, ast.Attribute) or func.attr != 'sort_source': continue
+		if not isinstance(func.value, ast.Name) or func.value.id != 'list_sort': continue
+		keywords = dict((k.arg, ast.unparse(k.value)) for k in node.keywords if k.arg)
+		args = [ast.unparse(a) for a in node.args]
+		calls.append({'tree': tree, 'args': args, 'list_key': args[1], 'adapter': args[3] if len(args) > 3 else None,
+			'fallback': keywords.get('fallback')})
+	return calls
+
+
+def _assigned_source(tree, name):
+	"""The source of the expression a module-level-visible name was last assigned, else name itself."""
+	found = name
+	for node in ast.walk(tree):
+		if isinstance(node, ast.Assign) and any(ast.unparse(t) == name for t in node.targets):
+			found = ast.unparse(node.value)
+	return found
+
+
+class CallSiteFallbackTests(_StubbedTestCase):
+	"""Pin that the two mixed-list call sites actually pass the provider-order fallback.
+
+	The engine-level tests above prove the fallback works; nothing else would notice a call site
+	that stopped passing one, and the result is every un-customised Trakt user list and TMDb list
+	silently reordering to title:asc on upgrade, with no legacy row left to recover from.
+	"""
+
+	def _single_call(self, path, adapter):
+		calls = [c for c in _sort_source_calls(path) if c['adapter'] == adapter]
+		self.assertEqual(1, len(calls), 'expected exactly one %s sort_source call in %s' % (adapter, path.name))
+		return calls[0]
+
+	def test_trakt_user_list_call_site_passes_the_payload_sort_as_fallback(self):
+		call = self._single_call(TRAKT_API, "'trakt_list'")
+		self.assertEqual("'trakt.list:%s' % list_id", call['list_key'])
+		self.assertIsNotNone(call['fallback'], 'the Trakt user list call site must pass a fallback')
+		self.assertEqual('list_sort.trakt_list_fallback(sort_by, sort_how)',
+			_assigned_source(call['tree'], call['fallback']))
+
+	def test_every_tmdb_list_leaves_get_tmdb_list_through_the_engine(self):
+		# 'recommendations' used to return early. That was equivalent to falling through - with the
+		# provider-order fallback and no override, sort_source hands the payload straight back - but
+		# it also made tmdb:recommendations the one list that could never honour an override.
+		with open(str(TMDB_LISTS), 'r', encoding='utf-8') as f:
+			tree = ast.parse(f.read())
+		found = [n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef) and n.name == 'get_tmdb_list']
+		self.assertEqual(1, len(found))
+		returns = [ast.unparse(n.value) for n in ast.walk(found[0]) if isinstance(n, ast.Return)]
+		self.assertTrue(returns, 'get_tmdb_list must return something')
+		for expression in returns:
+			self.assertTrue(expression.startswith('list_sort.sort_source('),
+				'every get_tmdb_list exit must go through sort_source, not %s' % expression)
+
+	def test_tmdb_call_site_fallback_literal_preserves_provider_order(self):
+		call = self._single_call(TMDB_LISTS, "'tmdb'")
+		self.assertEqual("'tmdb:%s' % list_id", call['list_key'])
+		self.assertIsNotNone(call['fallback'], 'the TMDb list call site must pass a fallback')
+		result = list_sort.sort_source(list(TMDB_ROWS), 'tmdb:8675309', None, 'tmdb',
+			fallback=ast.literal_eval(call['fallback']))
+		self.assertEqual(TMDB_PROVIDER_ORDER, [i['title'] for i in result])
+
+	def test_trakt_call_site_fallback_expression_preserves_the_payload_sort(self):
+		call = self._single_call(TRAKT_API, "'trakt_list'")
+		self.assertIsNotNone(call['fallback'], 'the Trakt user list call site must pass a fallback')
+		source = _assigned_source(call['tree'], call['fallback'])
+		fallback = eval(source, {'list_sort': list_sort, 'sort_by': 'rank', 'sort_how': 'asc'})
+		result = list_sort.sort_source(list(TRAKT_LIST_ROWS), 'trakt.list:99', None, 'trakt_list', fallback=fallback)
+		self.assertEqual([1, 2, 3], [i['rank'] for i in result])
+
+
+def _conditional_sort_source(path, adapter):
+	"""The source of the conditional expression whose true-branch is that adapter's sort_source call."""
+	with open(str(path), 'r', encoding='utf-8') as f:
+		tree = ast.parse(f.read())
+	for node in ast.walk(tree):
+		if not isinstance(node, ast.IfExp): continue
+		for inner in ast.walk(node.body):
+			if not isinstance(inner, ast.Call): continue
+			func = inner.func
+			if not isinstance(func, ast.Attribute) or func.attr != 'sort_source': continue
+			if len(inner.args) > 3 and ast.unparse(inner.args[3]) == adapter: return ast.unparse(node)
+	return None
+
+
+class TraktCallSiteBranchTests(_StubbedTestCase):
+	"""Pin which of get_trakt_list_contents' two branches each kind of list takes.
+
+	The fallback tests above read the sort_source call's arguments but never the condition choosing
+	between it and the ad-hoc apply(). Invert that condition and every stored user list silently
+	ignores its own override while every ad-hoc list gains a scope that can never have one.
+	"""
+
+	def _evaluate(self, list_id):
+		source = _conditional_sort_source(TRAKT_API, "'trakt_list'")
+		self.assertIsNotNone(source, 'the Trakt user list sort must stay a two-branch conditional')
+		calls = []
+
+		def _record(name, value):
+			def _call(*args, **kwargs):
+				calls.append((name, args, kwargs))
+				return value
+			return _call
+
+		fake = types.SimpleNamespace(sort_source=_record('sort_source', 'stored'),
+			apply=_record('apply', 'ad_hoc'), parse_spec=lambda raw, **kwargs: raw, TRAKT_LIST='TRAKT_LIST')
+		namespace = {'list_sort': fake, 'data': ['row'], 'list_id': list_id, 'payload_spec': 'rank:asc',
+			'settings': types.SimpleNamespace(ignore_articles=lambda: False)}
+		result = eval(source, namespace)
+		self.assertEqual(1, len(calls))
+		return result, calls[0]
+
+	def test_stored_user_list_is_sorted_through_its_override_scope(self):
+		result, call = self._evaluate('8675309')
+		self.assertEqual('stored', result, 'a list with an id must go through sort_source, not apply')
+		self.assertEqual('sort_source', call[0])
+		self.assertEqual('trakt.list:8675309', call[1][1])
+		self.assertEqual('rank:asc', call[2].get('fallback'))
+
+	def test_ad_hoc_list_without_an_id_is_sorted_by_its_payload_alone(self):
+		# No list_id means no scope an override could ever be stored under, so routing it through
+		# sort_source would resolve 'trakt.list:None' and drop the payload sort for every such list.
+		result, call = self._evaluate(None)
+		self.assertEqual('ad_hoc', result, 'a list with no id must go through apply, not sort_source')
+		self.assertEqual('apply', call[0])
+		self.assertEqual('rank:asc', call[1][1])
+
+
+class PersonalCallSiteTests(_StubbedTestCase):
+	"""Pin the personal call site's scope key and adapter.
+
+	Everything preserving a personal list's stored ordering rests on the key this call site builds
+	being byte-identical to the one migrate_legacy_stores() wrote the override under. Nothing else
+	compares the two, and a mismatch is invisible: the list simply comes back title-sorted.
+	"""
+
+	def _call(self):
+		calls = _sort_source_calls(PERSONAL_LISTS, function='get_personal_list')
+		self.assertEqual(1, len(calls), 'expected exactly one sort_source call in get_personal_list')
+		return calls[0]
+
+	def test_call_site_scope_is_the_key_the_migration_writes(self):
+		scope = eval(self._call()['list_key'], {'list_name': 'Faves', 'author': 'jo'})
+		migrated = list_sort.migrate_legacy_stores({}, {('Faves', 'jo'): '2'}, {})
+		self.assertEqual(['personal:Faves|jo'], list(migrated))
+		self.assertEqual('personal:Faves|jo', scope)
+
+		# And behaviourally: the migrated override must actually drive this call site's lookup.
+		OVERRIDES.update(migrated)
+		result = list_sort.sort_source(list(PERSONAL_ROWS), scope, None,
+			ast.literal_eval(self._call()['adapter']))
+		self.assertEqual(['Banana', 'Cherry', 'Alpha', 'Damson'], [i['title'] for i in result])
+
+	def test_call_site_uses_the_personal_adapter(self):
+		# The tmdb adapter has no date_added extractor, so swapping it silently degrades every
+		# date-added-sorted personal list to the payload order.
+		adapter = ast.literal_eval(self._call()['adapter'])
+		self.assertEqual('personal', adapter)
+		OVERRIDES['personal:Faves|jo'] = 'date_added:asc'
+		result = list_sort.sort_source(list(PERSONAL_ROWS), 'personal:Faves|jo', None, adapter)
+		self.assertEqual(['Damson', 'Alpha', 'Cherry', 'Banana'], [i['title'] for i in result])
+
+	def test_call_site_passes_no_fallback(self):
+		# Deliberate asymmetry with the Trakt and TMDb call sites: sort_order is a column on the
+		# personal_lists row itself, so every list always has a stored value and the migration always
+		# writes an override for it. A 'default:asc' fallback would mean DB insertion order.
+		self.assertIsNone(self._call()['fallback'])
+
+
+if __name__ == '__main__':
+	unittest.main()

--- a/tests/test_personal_lists_sort_overrides.py
+++ b/tests/test_personal_lists_sort_overrides.py
@@ -1,0 +1,246 @@
+"""Behavioural tests for the personal-list sort override helpers that talk to the store directly.
+
+_move_sort_override is the fix that keeps a personal list's sort override from being orphaned when
+the list or its author is renamed - the scope key embeds name and author, so a rename without it
+carries the row to a scope nothing will ever look up again. _delete_sort_override is the same fix
+applied to deletion: without it, deleting a list and recreating it with the same name and author
+silently inherits the deleted list's sort order. _current_sort_spec is what the "Currently ..." label
+reads, and _legacy_sort_code is the inverse lookup that keeps the legacy sort_order column in step.
+
+All four are pure apart from the store calls (and, for delete_personal_list, a couple of kodi_utils
+calls), so indexers/personal_lists.py is loaded the same way indexers/dialogs.py is loaded in
+tests/test_sort_ui.py: against stub caches/modules and the real modules/list_sort.py already loaded
+by tests/test_trakt_sync_list_sort.py.
+"""
+import importlib.util
+import sys
+import types
+import unittest
+
+from test_trakt_sync_list_sort import ROOT, list_sort
+
+LIB = ROOT / 'plugin.video.redlight' / 'resources' / 'lib'
+PERSONAL_LISTS = LIB / 'indexers' / 'personal_lists.py'
+
+_STUB_KEYS = ('caches', 'caches.settings_cache', 'caches.personal_lists_cache', 'caches.list_sort_cache',
+	'indexers', 'indexers.movies', 'indexers.tvshows',
+	'modules', 'modules.kodi_utils', 'modules.settings', 'modules.metadata', 'modules.utils', 'modules.list_sort')
+
+
+class _Store:
+	"""The list_sort_cache state the loaded module's lazy imports read and write, plus a record of
+	every call so a mutant that reorders or drops a call is visible even when the end state matches."""
+
+	def __init__(self):
+		self.overrides = {}
+		self.writable = True
+		self.get_calls = []
+		self.set_calls = []
+		self.delete_calls = []
+
+
+def _load_personal_lists(store):
+	caches = types.ModuleType('caches')
+	caches.__path__ = []
+	settings_cache = types.ModuleType('caches.settings_cache')
+	settings_cache.get_setting = lambda setting_id, fallback='': fallback
+
+	personal_lists_cache_module = types.ModuleType('caches.personal_lists_cache')
+	personal_lists_cache_module.personal_lists_cache = types.SimpleNamespace(
+		delete_list=lambda *a, **k: True, delete_list_contents=lambda *a, **k: True,
+		update_single_detail=lambda *a, **k: None)
+
+	list_sort_cache = types.ModuleType('caches.list_sort_cache')
+	list_sort_cache.scope_key = lambda list_key, media_type=None: list_key
+	list_sort_cache.normalize_media_type = lambda m: str(m).lower() if m else ''
+
+	def get_override(scope):
+		store.get_calls.append(scope)
+		return store.overrides.get(scope, '')
+
+	def set_override(scope, spec_string):
+		store.set_calls.append((scope, spec_string))
+		if not store.writable: return False
+		store.overrides[scope] = spec_string
+		return True
+
+	def delete_override(scope):
+		store.delete_calls.append(scope)
+		if not store.writable: return False
+		store.overrides.pop(scope, None)
+		return True
+
+	list_sort_cache.get_override = get_override
+	list_sort_cache.set_override = set_override
+	list_sort_cache.delete_override = delete_override
+
+	indexers = types.ModuleType('indexers')
+	indexers.__path__ = []
+	movies_module = types.ModuleType('indexers.movies')
+	movies_module.Movies = object
+	tvshows_module = types.ModuleType('indexers.tvshows')
+	tvshows_module.TVShows = object
+
+	modules = types.ModuleType('modules')
+	modules.__path__ = []
+	kodi_utils = types.ModuleType('modules.kodi_utils')
+	kodi_utils.confirm_dialog = lambda **kwargs: True
+	kodi_utils.kodi_refresh = lambda *a, **k: None
+	kodi_utils.notification = lambda *a, **k: None
+	kodi_utils.sleep = lambda *a, **k: None
+	kodi_utils.path_exists = lambda *a, **k: False
+	settings = types.ModuleType('modules.settings')
+	settings.ignore_articles = lambda: False
+	metadata = types.ModuleType('modules.metadata')
+	metadata.movie_meta = lambda *a, **k: {}
+	metadata.tvshow_meta = lambda *a, **k: {}
+	utils = types.ModuleType('modules.utils')
+	utils.TaskPool = object
+	utils.paginate_list = lambda *a, **k: None
+	utils.sort_for_article = lambda *a, **k: None
+	utils.get_datetime = lambda: None
+	utils.get_current_timestamp = lambda: 0
+	utils.make_image = lambda *a, **k: None
+	utils.download_image = lambda *a, **k: None
+	modules.kodi_utils = kodi_utils
+	modules.settings = settings
+	modules.metadata = metadata
+	modules.utils = utils
+	modules.list_sort = list_sort
+
+	sys.modules['caches'] = caches
+	sys.modules['caches.settings_cache'] = settings_cache
+	sys.modules['caches.personal_lists_cache'] = personal_lists_cache_module
+	sys.modules['caches.list_sort_cache'] = list_sort_cache
+	sys.modules['indexers'] = indexers
+	sys.modules['indexers.movies'] = movies_module
+	sys.modules['indexers.tvshows'] = tvshows_module
+	sys.modules['modules'] = modules
+	sys.modules['modules.kodi_utils'] = kodi_utils
+	sys.modules['modules.settings'] = settings
+	sys.modules['modules.metadata'] = metadata
+	sys.modules['modules.utils'] = utils
+	sys.modules['modules.list_sort'] = list_sort
+
+	spec = importlib.util.spec_from_file_location('personal_lists_source_under_test', PERSONAL_LISTS)
+	module = importlib.util.module_from_spec(spec)
+	spec.loader.exec_module(module)
+	return module
+
+
+class _PersonalListsTestCase(unittest.TestCase):
+	"""Other modules in this suite install their own 'caches'/'modules' stubs and never clean up, and
+	the run order is randomised, so save and restore everything this file replaces. Mirrors
+	tests/test_sort_ui.py's _DialogTestCase."""
+
+	def setUp(self):
+		self._saved = dict((k, sys.modules[k]) for k in _STUB_KEYS if k in sys.modules)
+		self.store = _Store()
+		self.personal_lists = _load_personal_lists(self.store)
+
+	def tearDown(self):
+		for key in _STUB_KEYS:
+			if key in self._saved: sys.modules[key] = self._saved[key]
+			else: sys.modules.pop(key, None)
+
+
+class MoveSortOverrideTests(_PersonalListsTestCase):
+	def test_a_successful_move_writes_the_new_scope_and_removes_the_old_one(self):
+		self.store.overrides['personal:Faves|jo'] = 'date_added:desc'
+		self.personal_lists._move_sort_override('Faves', 'jo', 'Favourites', 'jo')
+		self.assertEqual({'personal:Favourites|jo': 'date_added:desc'}, self.store.overrides)
+
+	def test_a_failed_write_leaves_the_old_row_intact(self):
+		self.store.overrides['personal:Faves|jo'] = 'date_added:desc'
+		self.store.writable = False
+		self.personal_lists._move_sort_override('Faves', 'jo', 'Favourites', 'jo')
+		# Not delete-then-set: the old row must still be there, not lost entirely.
+		self.assertEqual({'personal:Faves|jo': 'date_added:desc'}, self.store.overrides)
+		self.assertEqual([], self.store.delete_calls)
+
+	def test_equal_scopes_are_a_noop(self):
+		self.store.overrides['personal:Faves|jo'] = 'date_added:desc'
+		self.personal_lists._move_sort_override('Faves', 'jo', 'Faves', 'jo')
+		self.assertEqual({'personal:Faves|jo': 'date_added:desc'}, self.store.overrides)
+		self.assertEqual([], self.store.get_calls)
+		self.assertEqual([], self.store.set_calls)
+		self.assertEqual([], self.store.delete_calls)
+
+	def test_an_absent_row_is_a_noop(self):
+		self.personal_lists._move_sort_override('Faves', 'jo', 'Favourites', 'jo')
+		self.assertEqual({}, self.store.overrides)
+		self.assertEqual([], self.store.set_calls)
+		self.assertEqual([], self.store.delete_calls)
+
+
+class DeleteSortOverrideTests(_PersonalListsTestCase):
+	"""_delete_sort_override, called directly - the same defect class as the rename orphan, applied
+	to deletion."""
+
+	def test_deletes_the_rows_own_scope(self):
+		self.store.overrides['personal:Faves|jo'] = 'date_added:desc'
+		self.personal_lists._delete_sort_override('Faves', 'jo')
+		self.assertEqual({}, self.store.overrides)
+
+	def test_an_absent_row_is_a_noop(self):
+		self.personal_lists._delete_sort_override('Faves', 'jo')
+		self.assertEqual([], self.store.set_calls)
+
+
+class DeletePersonalListTests(_PersonalListsTestCase):
+	"""delete_personal_list() end to end: confirming the dialog deletes both the list row and its
+	sort override, so a list recreated later under the same name and author starts clean."""
+
+	def test_deleting_a_list_also_deletes_its_sort_override(self):
+		self.store.overrides['personal:Faves|jo'] = 'date_added:desc'
+		self.personal_lists.delete_personal_list({'list_name': 'Faves', 'author': 'jo'})
+		self.assertEqual({}, self.store.overrides)
+
+	def test_a_failed_list_delete_leaves_the_override_alone(self):
+		self.store.overrides['personal:Faves|jo'] = 'date_added:desc'
+		self.personal_lists.personal_lists_cache.delete_list = lambda *a, **k: False
+		self.personal_lists.delete_personal_list({'list_name': 'Faves', 'author': 'jo'})
+		self.assertEqual({'personal:Faves|jo': 'date_added:desc'}, self.store.overrides)
+
+	def test_cancelling_the_confirmation_leaves_everything_alone(self):
+		self.store.overrides['personal:Faves|jo'] = 'date_added:desc'
+		self.personal_lists.kodi_utils.confirm_dialog = lambda **kwargs: False
+		self.personal_lists.delete_personal_list({'list_name': 'Faves', 'author': 'jo'})
+		self.assertEqual({'personal:Faves|jo': 'date_added:desc'}, self.store.overrides)
+		self.assertEqual([], self.store.delete_calls)
+
+
+class CurrentSortSpecTests(_PersonalListsTestCase):
+	"""What the 'Currently ...' label in adjust_personal_list_properties actually reads."""
+
+	def test_with_no_override_the_spec_is_the_engine_default_not_the_provider_default(self):
+		"""The exact defect acceptance criterion 1 was about: a 'default:asc' fallback here would make
+		the label say 'Provider Default' for every list nobody has overridden, instead of the title
+		sort get_personal_list() actually falls back to."""
+		spec = self.personal_lists._current_sort_spec('Faves', 'jo')
+		self.assertEqual({'field': 'title', 'direction': 'asc'}, spec)
+
+	def test_a_stored_override_wins(self):
+		self.store.overrides['personal:Faves|jo'] = 'date_added:desc'
+		spec = self.personal_lists._current_sort_spec('Faves', 'jo')
+		self.assertEqual({'field': 'date_added', 'direction': 'desc'}, spec)
+
+
+class LegacySortCodeTests(_PersonalListsTestCase):
+	"""The legacy sort_order column value _legacy_sort_code writes back for a chosen spec."""
+
+	def test_every_legacy_code_with_a_unique_spec_round_trips(self):
+		# '' is excluded: it shares 'title:asc' with '0', and the inverse lookup prefers whichever
+		# comes first in LEGACY_PERSONAL_CODES, which is '0'.
+		for code, spec_string in list_sort.LEGACY_PERSONAL_CODES.items():
+			if code == '': continue
+			spec = list_sort.parse_spec(spec_string)
+			self.assertEqual(code, self.personal_lists._legacy_sort_code(spec), code)
+
+	def test_a_spec_with_no_legacy_equivalent_falls_back_to_code_zero(self):
+		self.assertEqual('0', self.personal_lists._legacy_sort_code({'field': 'title', 'direction': 'desc'}))
+		self.assertEqual('0', self.personal_lists._legacy_sort_code({'field': 'rank', 'direction': 'asc'}))
+
+
+if __name__ == '__main__':
+	unittest.main()

--- a/tests/test_settings_cache_calendar_migration.py
+++ b/tests/test_settings_cache_calendar_migration.py
@@ -1,0 +1,192 @@
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SETTINGS_CACHE_PATH = ROOT / 'plugin.video.redlight' / 'resources' / 'lib' / 'caches' / 'settings_cache.py'
+
+
+def _load_settings_cache_module():
+	properties = {}
+	kodi_utils = types.ModuleType('modules.kodi_utils')
+	kodi_utils.addon_fanart = lambda: ''
+	kodi_utils.addon_info = lambda key: 'test-version' if key == 'version' else ''
+	kodi_utils.clear_property = lambda key: properties.pop(key, None)
+	kodi_utils.get_property = lambda key: properties.get(key, '')
+	kodi_utils.is_android = lambda: False
+	kodi_utils.logger = lambda *args, **kwargs: None
+	kodi_utils.notification = lambda *args, **kwargs: None
+	kodi_utils.path_exists = lambda path: False
+	kodi_utils.schedule_widget_refresh = lambda **kwargs: None
+	kodi_utils.set_property = lambda key, value: properties.__setitem__(key, value)
+	kodi_utils.translate_path = lambda path: path
+
+	modules = types.ModuleType('modules')
+	modules.__path__ = []
+	modules.kodi_utils = kodi_utils
+	settings = types.ModuleType('modules.settings')
+	settings.migrate_cm_manager_order_for_upgrade = lambda: False
+	settings.migrate_external_scraper_context_menu_for_upgrade = lambda had_existing: False
+	settings.migrate_external_scraper_run_mode_for_upgrade = lambda had_existing: False
+	settings.migrate_external_scraper_slots_for_upgrade = lambda had_existing: False
+	settings.migrate_mdblist_context_menu_for_upgrade = lambda had_existing: False
+	settings.migrate_simkl_context_menu_for_upgrade = lambda had_existing: False
+	settings.migrate_trakt_watchlist_context_menu_for_upgrade = lambda had_existing: False
+	# sanitize_setting_value() reaches back into modules.settings for these option tables whenever the
+	# settings they belong to are present with a non-default value - which only happens once a profile
+	# already holds them, i.e. on a second sync_settings() run. An empty map sanitizes those settings to
+	# their declared defaults. Declared by name on purpose: a catch-all __getattr__ would answer a
+	# genuinely missing name with an empty map instead of failing loudly.
+	settings.watched_provider_options = lambda: {}
+	settings.subtitles_source_options = lambda: {}
+	settings.alert_timing_options = lambda next_episode=False: {}
+
+	caches = types.ModuleType('caches')
+	caches.__path__ = []
+	base_cache = types.ModuleType('caches.base_cache')
+	base_cache.connect_database = lambda name: None
+	base_cache.database_locations = lambda name: '%s.db' % name
+
+	sys.modules['modules'] = modules
+	sys.modules['modules.kodi_utils'] = kodi_utils
+	sys.modules['modules.settings'] = settings
+	sys.modules['caches'] = caches
+	sys.modules['caches.base_cache'] = base_cache
+
+	spec = importlib.util.spec_from_file_location('settings_cache_under_test', SETTINGS_CACHE_PATH)
+	module = importlib.util.module_from_spec(spec)
+	spec.loader.exec_module(module)
+	module._test_properties = properties
+	return module
+
+
+class FakeSettingsCache:
+	"""The production settings store, minus sqlite.
+
+	`db_readable = False` models the one failure the real store cannot report through get_all():
+	a locked or corrupt settings.db, where get_all() swallows the error and answers {} exactly as a
+	fresh install would. is_empty_strict() is the question that is allowed to fail, so it raises.
+	"""
+
+	def __init__(self, initial=None, db_readable=True):
+		self.data = dict(initial or {})
+		self.rows = {}
+		self.db_readable = db_readable
+
+	def clean_database(self):
+		return True
+
+	def clear_db_cache(self):
+		pass
+
+	def get_all(self):
+		if not self.db_readable: return {}
+		return dict(self.data)
+
+	def is_empty_strict(self):
+		if not self.db_readable: raise RuntimeError('database is locked')
+		return not self.data
+
+	def remove_setting(self, setting_id):
+		self.data.pop(setting_id, None)
+
+	def set_many(self, settings_list, load_properties=True):
+		for row in settings_list:
+			self.rows[row[0]] = row
+			self.data[row[0]] = row[3]
+
+	def set_memory_cache(self, setting_id, value):
+		pass
+
+	def write_db(self, setting_id, setting_value, setting_info=None):
+		self.data[setting_id] = setting_value
+
+
+class CalendarDisplayMigrationTests(unittest.TestCase):
+	@classmethod
+	def setUpClass(cls):
+		cls._original_sys_modules = {}
+		for key in ('modules', 'modules.kodi_utils', 'modules.settings', 'caches', 'caches.base_cache'):
+			if key in sys.modules:
+				cls._original_sys_modules[key] = sys.modules[key]
+		cls.module = _load_settings_cache_module()
+
+	@classmethod
+	def tearDownClass(cls):
+		for key in ('modules', 'modules.kodi_utils', 'modules.settings', 'caches', 'caches.base_cache'):
+			if key in cls._original_sys_modules:
+				sys.modules[key] = cls._original_sys_modules[key]
+			else:
+				sys.modules.pop(key, None)
+
+	def setUp(self):
+		self.module._test_properties.clear()
+		production_defaults = self.module.default_settings()
+		calendar_settings = {
+			s['setting_id']: s for s in production_defaults
+			if s['setting_id'] in ('single_ep_display', 'single_ep_display_widget', 'trakt.calendar_display', 'trakt.calendar_display_widget')
+		}
+		expected_calendar_metadata = {
+			'single_ep_display': {'setting_type': 'action', 'setting_default': '0',
+								  'settings_options': {'0': 'TITLE: SxE - EPISODE', '1': 'SxE - EPISODE', '2': 'EPISODE'}},
+			'single_ep_display_widget': {'setting_type': 'action', 'setting_default': '1',
+										 'settings_options': {'0': 'TITLE: SxE - EPISODE', '1': 'SxE - EPISODE', '2': 'EPISODE'}},
+			'trakt.calendar_display': {'setting_type': 'action', 'setting_default': '0',
+									   'settings_options': {'0': 'TITLE: SxE - EPISODE', '1': 'SxE - EPISODE', '2': 'EPISODE'}},
+			'trakt.calendar_display_widget': {'setting_type': 'action', 'setting_default': '1',
+											  'settings_options': {'0': 'TITLE: SxE - EPISODE', '1': 'SxE - EPISODE', '2': 'EPISODE'}},
+		}
+		for setting_id, expected_meta in expected_calendar_metadata.items():
+			actual = calendar_settings.get(setting_id, {})
+			self.assertEqual(expected_meta['setting_type'], actual.get('setting_type'),
+							 f"Production default for {setting_id} setting_type changed")
+			self.assertEqual(expected_meta['setting_default'], actual.get('setting_default'),
+							 f"Production default for {setting_id} setting_default changed")
+			self.assertEqual(expected_meta['settings_options'], actual.get('settings_options'),
+							 f"Production default for {setting_id} settings_options changed")
+
+	def _sync(self, initial):
+		cache = FakeSettingsCache(initial)
+		self.module.settings_cache = cache
+		result = self.module.sync_settings({'silent': 'true', 'load_properties': 'false', 'force': 'true'})
+		self.assertEqual('synced', result)
+		return cache
+
+	def test_upgrade_copies_existing_single_episode_preferences(self):
+		cache = self._sync({
+			'single_ep_display': '2',
+			'single_ep_display_widget': '0',
+		})
+
+		self.assertEqual('2', cache.data['trakt.calendar_display'])
+		self.assertEqual('0', cache.data['trakt.calendar_display_widget'])
+		self.assertEqual('EPISODE', cache.data['trakt.calendar_display_name'])
+		self.assertEqual('TITLE: SxE - EPISODE', cache.data['trakt.calendar_display_widget_name'])
+		self.assertEqual('0', cache.rows['trakt.calendar_display'][2])
+		self.assertEqual('1', cache.rows['trakt.calendar_display_widget'][2])
+
+	def test_fresh_install_uses_new_setting_defaults(self):
+		cache = self._sync({})
+
+		self.assertEqual('0', cache.data['trakt.calendar_display'])
+		self.assertEqual('1', cache.data['trakt.calendar_display_widget'])
+		self.assertEqual('TITLE: SxE - EPISODE', cache.data['trakt.calendar_display_name'])
+		self.assertEqual('SxE - EPISODE', cache.data['trakt.calendar_display_widget_name'])
+
+	def test_existing_calendar_preferences_are_not_overwritten(self):
+		cache = self._sync({
+			'single_ep_display': '2',
+			'single_ep_display_widget': '0',
+			'trakt.calendar_display': '1',
+			'trakt.calendar_display_widget': '2',
+		})
+
+		self.assertEqual('1', cache.data['trakt.calendar_display'])
+		self.assertEqual('2', cache.data['trakt.calendar_display_widget'])
+
+
+if __name__ == '__main__':
+	unittest.main()

--- a/tests/test_simkl_mdblist_sort.py
+++ b/tests/test_simkl_mdblist_sort.py
@@ -1,0 +1,264 @@
+import ast
+import sys
+import unittest
+
+from test_trakt_sync_list_sort import ROOT, list_sort, OVERRIDES, SETTINGS
+
+# Other test modules in this suite install their own fake 'caches'/'modules' stubs into
+# sys.modules at import time with no cleanup. list_sort.resolve() re-reads sys.modules lazily
+# on every call, so a test module that runs before this one (order is randomised) can clobber
+# the stub that test_trakt_sync_list_sort installed. Reinstall it here before each test,
+# mirroring the save/restore idiom in tests/test_list_sort_resolve.py and
+# tests/test_trakt_sync_list_sort.py, so these tests see OVERRIDES/SETTINGS regardless of
+# collection order.
+_STUB_KEYS = ('caches', 'caches.list_sort_cache', 'caches.settings_cache', 'modules', 'modules.settings')
+
+SIMKL_API = ROOT / 'plugin.video.redlight' / 'resources' / 'lib' / 'apis' / 'simkl_api.py'
+MDBLIST_API = ROOT / 'plugin.video.redlight' / 'resources' / 'lib' / 'apis' / 'mdblist_api.py'
+
+
+def _install_stubs():
+	import types
+	caches = types.ModuleType('caches')
+	caches.__path__ = []
+	list_sort_cache = types.ModuleType('caches.list_sort_cache')
+	_media = {'movie': 'movies', 'movies': 'movies', 'show': 'shows', 'shows': 'shows', 'tvshow': 'shows'}
+
+	def scope_key(list_key, media_type=None):
+		normalized = _media.get(str(media_type).lower(), '') if media_type else ''
+		return '%s:%s' % (list_key, normalized) if normalized else list_key
+
+	list_sort_cache.scope_key = scope_key
+	list_sort_cache.normalize_media_type = lambda m: _media.get(str(m).lower(), '') if m else ''
+	list_sort_cache.get_override = lambda scope: OVERRIDES.get(scope, '')
+	list_sort_cache.set_override = lambda scope, spec: True
+	settings_cache = types.ModuleType('caches.settings_cache')
+	settings_cache.get_setting = lambda setting_id, fallback='': SETTINGS.get(setting_id, fallback)
+	modules = types.ModuleType('modules')
+	modules.__path__ = []
+	settings = types.ModuleType('modules.settings')
+	settings.ignore_articles = lambda: True
+	sys.modules['caches'] = caches
+	sys.modules['caches.list_sort_cache'] = list_sort_cache
+	sys.modules['caches.settings_cache'] = settings_cache
+	sys.modules['modules'] = modules
+	sys.modules['modules.settings'] = settings
+
+
+class _StubbedTestCase(unittest.TestCase):
+	def setUp(self):
+		self._original_sys_modules = {}
+		for key in _STUB_KEYS:
+			if key in sys.modules:
+				self._original_sys_modules[key] = sys.modules[key]
+		_install_stubs()
+		OVERRIDES.clear()
+		SETTINGS.clear()
+
+	def tearDown(self):
+		for key in _STUB_KEYS:
+			if key in self._original_sys_modules:
+				sys.modules[key] = self._original_sys_modules[key]
+			else:
+				sys.modules.pop(key, None)
+		OVERRIDES.clear()
+		SETTINGS.clear()
+
+
+# Every fixture below is deliberately built so that no two of the orderings under test coincide:
+# the payload order is neither title order nor date order, date_added is NOT in title order
+# (Banana is newest but sorts second), and release_date/year is a third order distinct from both -
+# and, critically, distinct from date_added *reversed* as well. That last part is what makes the
+# release-date expectations mean anything: while RELEASE_ASC happened to equal DATE_ADDED_DESC, an
+# adapter whose release_date extractor read the date-added field would have satisfied every
+# release-date assertion here. So a sort_source that ignores media_type, reads the wrong default
+# setting, resolves under the wrong list_key, reads the wrong payload field, or always falls back
+# to DEFAULT_SPEC (title:asc) produces a visibly wrong list instead of accidentally matching the
+# expectation. 'The Alpha' carries a leading article so that title:asc also pins the
+# ignore_articles lookup - without the article strip it sorts last.
+#
+# The five distinct orderings, for reference:
+#   payload            Cherry, Banana, The Alpha
+#   title:asc          The Alpha, Banana, Cherry
+#   date_added:desc    Banana, The Alpha, Cherry
+#   release_date:asc   The Alpha, Cherry, Banana
+#   release_date:desc  Banana, Cherry, The Alpha
+SIMKL_ROWS = [
+	{'order': 1, 'title': 'Cherry', 'collected_at': '2024-01-01', 'released': '1999-01-01'},
+	{'order': 2, 'title': 'Banana', 'collected_at': '2024-01-03', 'released': '2001-01-01'},
+	{'order': 3, 'title': 'The Alpha', 'collected_at': '2024-01-02', 'released': '1995-01-01'},
+]
+
+MDBLIST_WATCHLIST_ROWS = [
+	{'title': 'Cherry', 'watchlist_at': '2024-01-01', 'release_date': '1999-01-01'},
+	{'title': 'Banana', 'watchlist_at': '2024-01-03', 'release_date': '2001-01-01'},
+	{'title': 'The Alpha', 'watchlist_at': '2024-01-02', 'release_date': '1995-01-01'},
+]
+
+MDBLIST_COLLECTION_ROWS = [
+	{'title': 'Cherry', 'collected_at': '2024-01-01', 'year': 1999},
+	{'title': 'Banana', 'collected_at': '2024-01-03', 'year': 2001},
+	{'title': 'The Alpha', 'collected_at': '2024-01-02', 'year': 1995},
+]
+
+TITLE_ASC = ['The Alpha', 'Banana', 'Cherry']
+DATE_ADDED_DESC = ['Banana', 'The Alpha', 'Cherry']
+RELEASE_ASC = ['The Alpha', 'Cherry', 'Banana']
+RELEASE_DESC = ['Banana', 'Cherry', 'The Alpha']
+
+
+class FixtureDistinctnessTests(unittest.TestCase):
+	"""The expectations above are only evidence while they disagree with each other.
+
+	RELEASE_ASC once equalled DATE_ADDED_DESC, which made every release-date assertion in this file
+	satisfiable by an adapter that sorted on the date-added field instead. Pin the distinctness so
+	the next edit to the fixture rows cannot quietly reintroduce that.
+	"""
+
+	PAYLOAD_ORDER = ['Cherry', 'Banana', 'The Alpha']
+
+	def test_no_two_expected_orderings_coincide(self):
+		orderings = {'payload': self.PAYLOAD_ORDER, 'title:asc': TITLE_ASC, 'date_added:desc': DATE_ADDED_DESC,
+			'release_date:asc': RELEASE_ASC, 'release_date:desc': RELEASE_DESC}
+		names = sorted(orderings)
+		for a in names:
+			for b in names:
+				if a >= b: continue
+				self.assertNotEqual(orderings[a], orderings[b], '%s and %s are the same sequence' % (a, b))
+
+	def test_release_order_is_not_date_added_order_in_either_direction(self):
+		"""Named separately because this is the exact coincidence that was found."""
+		self.assertNotEqual(RELEASE_ASC, DATE_ADDED_DESC)
+		self.assertNotEqual(RELEASE_ASC, list(reversed(DATE_ADDED_DESC)))
+		self.assertNotEqual(RELEASE_DESC, DATE_ADDED_DESC)
+
+	def test_the_three_fixtures_agree_on_that_ordering(self):
+		"""SIMKL uses 'released', watchlist uses 'release_date', collection uses an integer 'year'.
+		The tests share one RELEASE_ASC, so the three payloads have to encode the same order."""
+		by_title = lambda rows, key: [r['title'] for r in sorted(rows, key=lambda r: r[key])]
+		self.assertEqual(RELEASE_ASC, by_title(SIMKL_ROWS, 'released'))
+		self.assertEqual(RELEASE_ASC, by_title(MDBLIST_WATCHLIST_ROWS, 'release_date'))
+		self.assertEqual(RELEASE_ASC, by_title(MDBLIST_COLLECTION_ROWS, 'year'))
+		self.assertEqual(DATE_ADDED_DESC, list(reversed(by_title(SIMKL_ROWS, 'collected_at'))))
+		self.assertEqual(DATE_ADDED_DESC, list(reversed(by_title(MDBLIST_WATCHLIST_ROWS, 'watchlist_at'))))
+		self.assertEqual(DATE_ADDED_DESC, list(reversed(by_title(MDBLIST_COLLECTION_ROWS, 'collected_at'))))
+
+
+class SimklSortTests(_StubbedTestCase):
+	def test_shows_and_movies_differ(self):
+		SETTINGS['redlight.sort.default.movies'] = 'date_added:desc'
+		SETTINGS['redlight.sort.default.shows'] = 'title:asc'
+		movies = list_sort.sort_source(list(SIMKL_ROWS), 'simkl', 'movies', 'simkl')
+		shows = list_sort.sort_source(list(SIMKL_ROWS), 'simkl', 'shows', 'simkl')
+		self.assertEqual(DATE_ADDED_DESC, [i['title'] for i in movies])
+		self.assertEqual(TITLE_ASC, [i['title'] for i in shows])
+		self.assertNotEqual([i['title'] for i in movies], [i['title'] for i in shows])
+
+	def test_release_date_ascending(self):
+		SETTINGS['redlight.sort.default.movies'] = 'release_date:asc'
+		result = list_sort.sort_source(list(SIMKL_ROWS), 'simkl', 'movies', 'simkl')
+		self.assertEqual(RELEASE_ASC, [i['title'] for i in result])
+
+	def test_per_list_override_beats_the_mediatype_default(self):
+		SETTINGS['redlight.sort.default.shows'] = 'title:asc'
+		OVERRIDES['simkl:shows'] = 'date_added:desc'
+		result = list_sort.sort_source(list(SIMKL_ROWS), 'simkl', 'shows', 'simkl')
+		self.assertEqual(DATE_ADDED_DESC, [i['title'] for i in result])
+
+
+class MdblistSortTests(_StubbedTestCase):
+	def test_watchlist_date_added_descending(self):
+		SETTINGS['redlight.sort.default.movies'] = 'date_added:desc'
+		result = list_sort.sort_source(list(MDBLIST_WATCHLIST_ROWS), 'mdblist.watchlist', 'movies', 'mdblist_watchlist')
+		self.assertEqual(DATE_ADDED_DESC, [i['title'] for i in result])
+
+	def test_watchlist_shows_read_the_shows_default(self):
+		SETTINGS['redlight.sort.default.movies'] = 'title:asc'
+		SETTINGS['redlight.sort.default.shows'] = 'release_date:asc'
+		result = list_sort.sort_source(list(MDBLIST_WATCHLIST_ROWS), 'mdblist.watchlist', 'shows', 'mdblist_watchlist')
+		self.assertEqual(RELEASE_ASC, [i['title'] for i in result])
+
+	def test_collection_release_date_ascending_now_supported(self):
+		SETTINGS['redlight.sort.default.movies'] = 'release_date:asc'
+		result = list_sort.sort_source(list(MDBLIST_COLLECTION_ROWS), 'mdblist.collection', 'movies', 'mdblist_collection')
+		self.assertEqual(RELEASE_ASC, [i['title'] for i in result])
+
+	def test_collection_override_independent_of_watchlist(self):
+		SETTINGS['redlight.sort.default.movies'] = 'title:asc'
+		OVERRIDES['mdblist.collection:movies'] = 'release_date:desc'
+		collection = list_sort.sort_source(list(MDBLIST_COLLECTION_ROWS), 'mdblist.collection', 'movies', 'mdblist_collection')
+		watchlist = list_sort.sort_source(list(MDBLIST_WATCHLIST_ROWS), 'mdblist.watchlist', 'movies', 'mdblist_watchlist')
+		self.assertEqual(RELEASE_DESC, [i['title'] for i in collection])
+		self.assertEqual(TITLE_ASC, [i['title'] for i in watchlist])
+
+
+def _sort_source_calls(path):
+	"""Every list_sort.sort_source(...) call in a module, as (list_key, media_type, adapter_name).
+
+	media_type is None where the call site passes a variable (the media_kind parameter) rather than
+	a literal. Parsed from source with ast rather than imported, because the api modules pull in the
+	Kodi runtime.
+	"""
+	with open(str(path), 'r', encoding='utf-8') as f:
+		tree = ast.parse(f.read())
+	calls = []
+	for node in ast.walk(tree):
+		if not isinstance(node, ast.Call): continue
+		func = node.func
+		if not isinstance(func, ast.Attribute) or func.attr != 'sort_source': continue
+		if not isinstance(func.value, ast.Name) or func.value.id != 'list_sort': continue
+		literals = [a.value if isinstance(a, ast.Constant) else None for a in node.args]
+		calls.append((literals[1], literals[2], literals[3]))
+	return calls
+
+
+class CallSiteScopeAgreementTests(_StubbedTestCase):
+	"""Pin the agreement between the list_key/adapter literals the api call sites pass and the
+	override scopes Task 5's migration writes. Nothing else in the suite would notice a
+	one-character drift on either side ('mdblist_watchlist' vs 'mdblist.watchlist'), and the
+	result would be every migrated user silently dropped back to title:asc."""
+
+	# sort.simkl deliberately differs from sort.watchlist so the migration emits explicit
+	# 'simkl:*' overrides (it skips them when they match the global default it just seeded).
+	LEGACY = {'sort.watchlist': '0', 'sort.collection': '2', 'sort.simkl': '1',
+		'tmdbsort.watchlist': '4', 'tmdbsort.favorites': '4'}
+
+	def test_simkl_call_sites_use_the_migrated_list_key_and_a_real_adapter(self):
+		calls = _sort_source_calls(SIMKL_API)
+		self.assertTrue(calls)
+		for list_key, _media_type, adapter in calls:
+			self.assertEqual('simkl', list_key)
+			self.assertIn(adapter, list_sort.ADAPTERS)
+			self.assertEqual('simkl', adapter)
+		# _simkl_fetch_tv_status re-sorts the merged shows+anime list under a hardcoded 'shows'.
+		self.assertIn(('simkl', 'shows', 'simkl'), calls)
+
+	def test_mdblist_call_sites_use_the_migrated_list_keys_and_real_adapters(self):
+		calls = _sort_source_calls(MDBLIST_API)
+		self.assertEqual({('mdblist.watchlist', 'mdblist_watchlist'), ('mdblist.collection', 'mdblist_collection')},
+			set((list_key, adapter) for list_key, _media_type, adapter in calls))
+		for _list_key, _media_type, adapter in calls:
+			self.assertIn(adapter, list_sort.ADAPTERS)
+
+	def test_every_call_site_resolves_to_the_scope_the_migration_wrote(self):
+		overrides = list_sort.migrate_legacy_sort_settings(dict(self.LEGACY))['overrides']
+		OVERRIDES.update(overrides)
+		calls = _sort_source_calls(SIMKL_API) + _sort_source_calls(MDBLIST_API)
+		self.assertTrue(calls)
+		for list_key, media_type, _adapter in calls:
+			for candidate in ((media_type,) if media_type else ('movies', 'shows')):
+				scope = '%s:%s' % (list_key, candidate)
+				self.assertIn(scope, overrides)
+				self.assertEqual(list_sort.parse_spec(overrides[scope]), list_sort.resolve(list_key, candidate))
+
+	def test_migrated_simkl_and_mdblist_overrides_are_all_reachable_from_a_call_site(self):
+		overrides = list_sort.migrate_legacy_sort_settings(dict(self.LEGACY))['overrides']
+		call_keys = set(c[0] for c in _sort_source_calls(SIMKL_API) + _sort_source_calls(MDBLIST_API))
+		migrated_keys = set(s.rsplit(':', 1)[0] for s in overrides
+			if s.startswith('simkl:') or s.startswith('mdblist.'))
+		self.assertEqual({'simkl', 'mdblist.watchlist', 'mdblist.collection'}, migrated_keys)
+		self.assertEqual(migrated_keys, call_keys)
+
+
+if __name__ == '__main__':
+	unittest.main()

--- a/tests/test_sort_ui.py
+++ b/tests/test_sort_ui.py
@@ -1,0 +1,701 @@
+"""The settings rows and dialogs that drive the unified sort engine.
+
+Two halves. The first loads indexers/dialogs.py against stub Kodi modules and exercises the
+two stage picker and both handlers as ordinary functions - they are pure apart from
+select_dialog(). The second pins the string literals that the skin XML, the router and the
+call sites have to agree on: a setting id, a mode name, a scope key or an adapter name that
+drifts by one character breaks the feature silently, and nothing else in the suite notices.
+
+The skin XML and the Kodi dialogs themselves cannot be run here (there is no Kodi runtime);
+the manual checklist in docs/superpowers/plans/2026-07-20-unified-list-sort.md Task 9 Step 6
+covers what these tests cannot.
+"""
+import ast
+import importlib.util
+import re
+import sys
+import types
+import unittest
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+from test_trakt_sync_list_sort import ROOT, list_sort
+
+LIB = ROOT / 'plugin.video.redlight' / 'resources' / 'lib'
+DIALOGS = LIB / 'indexers' / 'dialogs.py'
+NAVIGATOR = LIB / 'indexers' / 'navigator.py'
+PERSONAL_LISTS = LIB / 'indexers' / 'personal_lists.py'
+TMDB_LISTS = LIB / 'indexers' / 'tmdb_lists.py'
+TRAKT_LISTS = LIB / 'indexers' / 'trakt_lists.py'
+ROUTER = LIB / 'modules' / 'router.py'
+SIMKL_API = LIB / 'apis' / 'simkl_api.py'
+MDBLIST_API = LIB / 'apis' / 'mdblist_api.py'
+TRAKT_API = LIB / 'apis' / 'trakt_api.py'
+SETTINGS_CACHE = LIB / 'caches' / 'settings_cache.py'
+SETTINGS_MANAGER_XML = ROOT / 'plugin.video.redlight' / 'resources' / 'skins' / 'Default' / '1080i' / 'settings_manager.xml'
+
+_STUB_KEYS = ('caches', 'caches.list_sort_cache', 'caches.settings_cache', 'modules', 'modules.kodi_utils',
+	'modules.list_sort', 'modules.settings')
+
+
+def _source(path):
+	with open(str(path), 'r', encoding='utf-8') as f:
+		return f.read()
+
+
+def _tree(path):
+	return ast.parse(_source(path))
+
+
+def _function(path, name):
+	for node in ast.walk(_tree(path)):
+		if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name: return node
+	raise AssertionError('%s not found in %s' % (name, path.name))
+
+
+def _called_names(node):
+	"""Every plain function name called anywhere inside an ast node."""
+	names = set()
+	for child in ast.walk(node):
+		if not isinstance(child, ast.Call): continue
+		if isinstance(child.func, ast.Name): names.add(child.func.id)
+		elif isinstance(child.func, ast.Attribute): names.add(child.func.attr)
+	return names
+
+
+def _string_constants(node, prefix):
+	return set(i.value for i in ast.walk(node)
+		if isinstance(i, ast.Constant) and isinstance(i.value, str) and i.value.startswith(prefix))
+
+
+def _call_args(node, called_name):
+	"""(positional literal values, keyword literal values) for the first called_name(...) call found
+	in node. None for any argument that is not itself a literal constant (a Name, a BinOp, ...)."""
+	for child in ast.walk(node):
+		if not isinstance(child, ast.Call): continue
+		func = child.func
+		name = func.id if isinstance(func, ast.Name) else (func.attr if isinstance(func, ast.Attribute) else None)
+		if name != called_name: continue
+		positional = [a.value if isinstance(a, ast.Constant) else None for a in child.args]
+		keywords = dict((k.arg, k.value.value if isinstance(k.value, ast.Constant) else None)
+			for k in child.keywords if k.arg)
+		return positional, keywords
+	raise AssertionError('%s(...) not called in %s' % (called_name, node.name if hasattr(node, 'name') else node))
+
+
+def _call_dict_literal(node, called_name, index=0):
+	"""The {str: str} literal at position `index` of the first called_name(...) call found in node."""
+	for child in ast.walk(node):
+		if not isinstance(child, ast.Call): continue
+		func = child.func
+		name = func.id if isinstance(func, ast.Name) else (func.attr if isinstance(func, ast.Attribute) else None)
+		if name != called_name: continue
+		if len(child.args) <= index or not isinstance(child.args[index], ast.Dict): continue
+		arg = child.args[index]
+		return dict((k.value, v.value) for k, v in zip(arg.keys, arg.values)
+			if isinstance(k, ast.Constant) and isinstance(v, ast.Constant))
+	raise AssertionError('%s(...) with a dict literal at position %d not found' % (called_name, index))
+
+
+# --------------------------------------------------------------------------------------------
+# Half one: the dialog handlers, loaded against stubs and run for real.
+# --------------------------------------------------------------------------------------------
+
+class _Dialogs:
+	"""The loaded dialogs module plus the stub state its handlers read and write."""
+
+	def __init__(self):
+		self.selections = []
+		self.dialog_calls = []
+		self.settings = {}
+		self.overrides = {}
+		self.refreshed = 0
+		self.ok_dialogs = []
+		self.store_writable = True
+
+
+def _load_dialogs(state):
+	caches = types.ModuleType('caches')
+	caches.__path__ = []
+	settings_cache = types.ModuleType('caches.settings_cache')
+	settings_cache.get_setting = lambda setting_id, fallback='': state.settings.get(setting_id, fallback)
+
+	def set_setting(setting_id, value, *args, **kwargs):
+		state.settings['redlight.%s' % setting_id] = value
+		return True
+
+	settings_cache.set_setting = set_setting
+	settings_cache.set_default = lambda *args, **kwargs: True
+	settings_cache.default_setting_values = lambda *args, **kwargs: {}
+
+	list_sort_cache = types.ModuleType('caches.list_sort_cache')
+	_media = {'movie': 'movies', 'movies': 'movies', 'show': 'shows', 'shows': 'shows', 'tvshow': 'shows'}
+	list_sort_cache.normalize_media_type = lambda m: _media.get(str(m).lower(), '') if m else ''
+	list_sort_cache.scope_key = lambda list_key, media_type=None: (
+		'%s:%s' % (list_key, _media[str(media_type).lower()]) if media_type and str(media_type).lower() in _media else list_key)
+	list_sort_cache.get_override = lambda scope: state.overrides.get(scope, '')
+
+	def set_override(scope, spec_string):
+		if not state.store_writable: return False
+		state.overrides[scope] = spec_string
+		return True
+
+	def delete_override(scope):
+		if not state.store_writable: return False
+		state.overrides.pop(scope, None)
+		return True
+
+	list_sort_cache.set_override = set_override
+	list_sort_cache.delete_override = delete_override
+
+	kodi_utils = types.ModuleType('modules.kodi_utils')
+
+	def select_dialog(choices, **kwargs):
+		state.dialog_calls.append({'choices': list(choices), 'kwargs': dict(kwargs)})
+		if not state.selections: return None
+		return state.selections.pop(0)
+
+	kodi_utils.select_dialog = select_dialog
+
+	def kodi_refresh(*args, **kwargs):
+		state.refreshed += 1
+
+	kodi_utils.kodi_refresh = kodi_refresh
+	kodi_utils.ok_dialog = lambda *args, **kwargs: state.ok_dialogs.append(args)
+	settings = types.ModuleType('modules.settings')
+	settings.ignore_articles = lambda: False
+	modules = types.ModuleType('modules')
+	modules.__path__ = []
+	modules.kodi_utils = kodi_utils
+	modules.settings = settings
+	modules.list_sort = list_sort
+	sys.modules['caches'] = caches
+	sys.modules['caches.settings_cache'] = settings_cache
+	sys.modules['caches.list_sort_cache'] = list_sort_cache
+	sys.modules['modules'] = modules
+	sys.modules['modules.kodi_utils'] = kodi_utils
+	sys.modules['modules.list_sort'] = list_sort
+	sys.modules['modules.settings'] = settings
+	spec = importlib.util.spec_from_file_location('dialogs_source_under_test', DIALOGS)
+	module = importlib.util.module_from_spec(spec)
+	spec.loader.exec_module(module)
+	return module
+
+
+class _DialogTestCase(unittest.TestCase):
+	"""Other modules in this suite install their own 'caches'/'modules' stubs and never clean up,
+	and the run order is randomised, so save and restore everything this file replaces."""
+
+	def setUp(self):
+		self._saved = dict((k, sys.modules[k]) for k in _STUB_KEYS if k in sys.modules)
+		self.state = _Dialogs()
+		self.dialogs = _load_dialogs(self.state)
+
+	def tearDown(self):
+		for key in _STUB_KEYS:
+			if key in self._saved: sys.modules[key] = self._saved[key]
+			else: sys.modules.pop(key, None)
+
+	def line1s(self, call_index):
+		import json
+		return [i['line1'] for i in json.loads(self.state.dialog_calls[call_index]['kwargs']['items'])]
+
+
+class PickSortSpecTests(_DialogTestCase):
+	def test_field_then_direction(self):
+		self.state.selections = ['date_added', 'desc']
+		spec = self.dialogs._pick_sort_spec('Heading', 'trakt_sync')
+		self.assertEqual({'field': 'date_added', 'direction': 'desc'}, spec)
+		self.assertEqual(2, len(self.state.dialog_calls))
+		self.assertEqual('Heading: Field', self.state.dialog_calls[0]['kwargs']['heading'])
+		self.assertEqual('Heading: Direction', self.state.dialog_calls[1]['kwargs']['heading'])
+
+	def test_only_the_adapters_own_fields_are_offered(self):
+		self.state.selections = ['title', 'asc']
+		self.dialogs._pick_sort_spec('Heading', 'trakt_sync')
+		self.assertEqual(list(list_sort.field_choices('trakt_sync')), self.state.dialog_calls[0]['choices'])
+		self.assertNotIn('rank', self.state.dialog_calls[0]['choices'])
+
+	def test_a_directionless_field_skips_the_direction_dialog(self):
+		self.state.selections = ['random']
+		spec = self.dialogs._pick_sort_spec('Heading', 'trakt_sync')
+		self.assertEqual({'field': 'random', 'direction': 'asc'}, spec)
+		self.assertEqual(1, len(self.state.dialog_calls))
+
+	def test_cancelling_either_stage_returns_none(self):
+		self.state.selections = []
+		self.assertIsNone(self.dialogs._pick_sort_spec('Heading', 'trakt_sync'))
+		self.state.dialog_calls = []
+		self.state.selections = ['title']
+		self.assertIsNone(self.dialogs._pick_sort_spec('Heading', 'trakt_sync'))
+		self.assertEqual(2, len(self.state.dialog_calls))
+
+	def test_use_default_is_first_and_only_when_asked_for(self):
+		self.state.selections = ['use_default']
+		self.assertEqual('use_default', self.dialogs._pick_sort_spec('Heading', 'trakt_sync', allow_default=True))
+		self.assertEqual('use_default', self.state.dialog_calls[0]['choices'][0])
+		self.state.dialog_calls = []
+		self.state.selections = ['title', 'asc']
+		self.dialogs._pick_sort_spec('Heading', 'trakt_sync')
+		self.assertNotIn('use_default', self.state.dialog_calls[0]['choices'])
+
+	def test_the_current_spec_is_marked_in_both_stages(self):
+		self.state.selections = ['date_added', 'desc']
+		current = {'field': 'date_added', 'direction': 'desc'}
+		self.dialogs._pick_sort_spec('Heading', 'trakt_sync', current=current)
+		field_marked = [i for i in self.line1s(0) if 'CURRENT' in i]
+		direction_marked = [i for i in self.line1s(1) if 'CURRENT' in i]
+		self.assertEqual(1, len(field_marked))
+		self.assertTrue(field_marked[0].startswith(list_sort.FIELD_LABELS['date_added']))
+		self.assertEqual(1, len(direction_marked))
+		self.assertTrue(direction_marked[0].startswith('Descending'))
+
+	def test_the_direction_marker_is_dropped_when_the_field_changes(self):
+		self.state.selections = ['title', 'asc']
+		self.dialogs._pick_sort_spec('Heading', 'trakt_sync', current={'field': 'date_added', 'direction': 'desc'})
+		self.assertEqual([], [i for i in self.line1s(1) if 'CURRENT' in i])
+
+	def test_an_unknown_adapter_returns_none_instead_of_an_empty_dialog(self):
+		self.assertIsNone(self.dialogs._pick_sort_spec('Heading', 'not_an_adapter'))
+		self.assertEqual([], self.state.dialog_calls)
+
+
+class SortDefaultChoiceTests(_DialogTestCase):
+	def test_writes_the_spec_and_its_label_for_the_chosen_mediatype(self):
+		self.state.selections = ['release_date', 'desc']
+		self.dialogs.sort_default_choice({'media_type': 'movies'})
+		self.assertEqual('release_date:desc', self.state.settings['redlight.sort.default.movies'])
+		self.assertEqual('Release Date (descending)', self.state.settings['redlight.sort.default.movies_name'])
+		self.assertNotIn('redlight.sort.default.shows', self.state.settings)
+		self.assertEqual(1, self.state.refreshed)
+
+	def test_the_setting_id_is_the_one_resolve_reads(self):
+		self.state.selections = ['title', 'asc']
+		self.dialogs.sort_default_choice({'media_type': 'shows'})
+		self.assertIn(list_sort.DEFAULT_SETTING_IDS['shows'], self.state.settings)
+
+	def test_cancelling_writes_nothing(self):
+		self.state.selections = []
+		self.dialogs.sort_default_choice({'media_type': 'movies'})
+		self.assertEqual({}, self.state.settings)
+		self.assertEqual(0, self.state.refreshed)
+
+	def test_the_picker_offers_exactly_the_governed_adapters_intersection(self):
+		self.state.selections = ['title', 'asc']
+		self.dialogs.sort_default_choice({'media_type': 'movies'})
+		offered = self.state.dialog_calls[0]['choices']
+		expected = [i for i in list_sort.VALID_FIELDS
+			if all(i in list_sort.field_choices(a) for a in list_sort.DEFAULT_GOVERNED_ADAPTERS)]
+		self.assertEqual(expected, offered)
+		# Spelled out so a change to the adapters has to be looked at rather than absorbed.
+		self.assertEqual(['title', 'date_added', 'release_date', 'random'], offered)
+
+	def test_every_offered_field_can_be_extracted_by_every_governed_adapter(self):
+		"""The defect this replaces: the picker was built from field_choices('trakt_list') and offered
+		rank/rating/votes/runtime. resolve() hands the stored spec to whichever adapter is building the
+		list; with no extractor for the field apply() returns the payload untouched, so picking one of
+		those four silently left every mediatype-split list in raw cache order."""
+		self.state.selections = ['title', 'asc']
+		self.dialogs.sort_default_choice({'media_type': 'movies'})
+		offered = self.state.dialog_calls[0]['choices']
+		self.assertTrue(offered)
+		for field in offered:
+			for name in list_sort.DEFAULT_GOVERNED_ADAPTERS:
+				adapter = list_sort.ADAPTERS[name]
+				self.assertIn(field, adapter['capabilities'], '%s cannot sort by %s' % (name, field))
+				if field in list_sort.DIRECTIONLESS_FIELDS: continue
+				self.assertIn(field, adapter['fields'], '%s has no %s extractor' % (name, field))
+
+	def test_the_stored_default_is_marked_as_current(self):
+		self.state.settings['redlight.sort.default.movies'] = 'date_added:desc'
+		self.state.selections = ['title', 'asc']
+		self.dialogs.sort_default_choice({'media_type': 'movies'})
+		marked = [i for i in self.line1s(0) if 'CURRENT' in i]
+		self.assertEqual(1, len(marked))
+		self.assertTrue(marked[0].startswith(list_sort.FIELD_LABELS['date_added']))
+
+
+class ListSortOverrideChoiceTests(_DialogTestCase):
+	def test_a_mediatype_split_list_writes_a_suffixed_scope(self):
+		self.state.selections = ['date_added', 'desc']
+		self.dialogs.list_sort_override_choice({'list_key': 'trakt.watchlist', 'media_type': 'movies', 'adapter': 'trakt_sync'})
+		self.assertEqual({'trakt.watchlist:movies': 'date_added:desc'}, self.state.overrides)
+		self.assertEqual(1, self.state.refreshed)
+
+	def test_a_mixed_list_writes_the_bare_scope(self):
+		self.state.selections = ['rank', 'asc']
+		self.dialogs.list_sort_override_choice({'list_key': 'trakt.list:42', 'adapter': 'trakt_list'})
+		self.assertEqual({'trakt.list:42': 'rank:asc'}, self.state.overrides)
+
+	def test_use_default_deletes_the_override(self):
+		self.state.overrides['trakt.watchlist:shows'] = 'title:asc'
+		self.state.selections = ['use_default']
+		self.dialogs.list_sort_override_choice({'list_key': 'trakt.watchlist', 'media_type': 'shows', 'adapter': 'trakt_sync'})
+		self.assertEqual({}, self.state.overrides)
+		self.assertEqual(1, self.state.refreshed)
+
+	def test_a_write_failure_reports_instead_of_refreshing(self):
+		self.state.store_writable = False
+		self.state.selections = ['title', 'asc']
+		self.dialogs.list_sort_override_choice({'list_key': 'simkl', 'media_type': 'movies', 'adapter': 'simkl'})
+		self.assertEqual(0, self.state.refreshed)
+		self.assertEqual(1, len(self.state.ok_dialogs))
+
+	def test_the_current_marker_follows_the_stored_override(self):
+		self.state.overrides['mdblist.collection:movies'] = 'release_date:desc'
+		self.state.selections = ['title', 'asc']
+		self.dialogs.list_sort_override_choice(
+			{'list_key': 'mdblist.collection', 'media_type': 'movies', 'adapter': 'mdblist_collection'})
+		marked = [i for i in self.line1s(0) if 'CURRENT' in i]
+		self.assertEqual([list_sort.FIELD_LABELS['release_date']], [i.split('  ')[0] for i in marked])
+
+	def test_with_no_override_the_current_marker_follows_the_callers_fallback(self):
+		"""A Trakt user list is ordered by the sort Trakt declares for it until someone overrides it,
+		so marking title as current - what resolve() alone would say - would be a lie."""
+		self.state.selections = ['title', 'asc']
+		self.dialogs.list_sort_override_choice({'list_key': 'trakt.list:7', 'adapter': 'trakt_list', 'fallback': 'rank:asc'})
+		marked = [i for i in self.line1s(0) if 'CURRENT' in i]
+		self.assertEqual([list_sort.FIELD_LABELS['rank']], [i.split('  ')[0] for i in marked])
+
+	def test_cancelling_leaves_an_existing_override_alone(self):
+		self.state.overrides['simkl:shows'] = 'date_added:desc'
+		self.state.selections = []
+		self.dialogs.list_sort_override_choice({'list_key': 'simkl', 'media_type': 'shows', 'adapter': 'simkl'})
+		self.assertEqual({'simkl:shows': 'date_added:desc'}, self.state.overrides)
+		self.assertEqual(0, self.state.refreshed)
+
+
+# --------------------------------------------------------------------------------------------
+# Half two: the literals the XML, the router and the call sites have to agree on.
+# --------------------------------------------------------------------------------------------
+
+def _skin_items():
+	"""(onclick, {property name: text}) for every <item> in the settings manager skin."""
+	root = ET.parse(str(SETTINGS_MANAGER_XML)).getroot()
+	items = []
+	for item in root.iter('item'):
+		onclick = ''.join(i.text or '' for i in item.findall('onclick'))
+		properties = dict((i.get('name'), i.text or '') for i in item.findall('property'))
+		items.append((onclick, properties))
+	return items
+
+
+def _router_branch_literals():
+	"""The substring each router branch tests, in source order, up to and including 'choice'."""
+	literals = []
+	for line in _source(ROUTER).splitlines():
+		match = re.search(r"(?:if|elif) '([^']+)' in mode|mode\.startswith\('([^']+)'\)", line)
+		if not match: continue
+		literal = match.group(1) or match.group(2)
+		literals.append(literal)
+		if literal == 'choice': break
+	return literals
+
+
+class SkinRowTests(unittest.TestCase):
+	def test_the_two_default_rows_exist_and_point_at_the_dialog_handler(self):
+		rows = [(onclick, props) for onclick, props in _skin_items() if 'mode=sort_default_choice' in onclick]
+		self.assertEqual(2, len(rows))
+		media_types = []
+		for onclick, props in rows:
+			media_type = re.search(r'media_type=(\w+)', onclick).group(1)
+			media_types.append(media_type)
+			self.assertIn(media_type, list_sort.DEFAULT_SETTING_IDS)
+			self.assertEqual('action', props['setting_type'])
+			# The row displays the companion _name setting the handler writes.
+			self.assertIn('%s_name' % list_sort.DEFAULT_SETTING_IDS[media_type], props['setting_value'])
+		self.assertEqual(['movies', 'shows'], sorted(media_types))
+
+	def test_the_rows_are_not_gated_on_any_provider_being_logged_in(self):
+		"""The old rows were Trakt/Simkl gated. These two apply to every provider's lists."""
+		root = ET.parse(str(SETTINGS_MANAGER_XML)).getroot()
+		for item in root.iter('item'):
+			onclick = ''.join(i.text or '' for i in item.findall('onclick'))
+			if 'mode=sort_default_choice' not in onclick: continue
+			visibles = [i.text or '' for i in item.findall('visible')]
+			self.assertEqual(1, len(visibles))
+			self.assertNotIn('String.IsEqual', visibles[0])
+
+	def test_the_settings_the_rows_write_are_declared_in_default_settings(self):
+		declared = set(re.findall(r"'setting_id': '([^']+)'", _source(SETTINGS_CACHE)))
+		for setting_id in list_sort.DEFAULT_SETTING_IDS.values():
+			bare = setting_id.replace('redlight.', '')
+			self.assertIn(bare, declared)
+			self.assertIn('%s_name' % bare, declared)
+
+	def test_the_superseded_per_provider_sort_rows_are_gone(self):
+		onclicks = ' '.join(onclick for onclick, _props in _skin_items())
+		for setting_id in ('sort.watchlist', 'sort.collection', 'sort.simkl', 'tmdbsort.watchlist', 'tmdbsort.favorites'):
+			self.assertNotIn('setting_id=%s' % setting_id, onclicks)
+
+	def test_the_tmdb_list_display_order_row_is_untouched(self):
+		"""A different feature: it orders the folder of lists, not the contents of one."""
+		onclicks = ' '.join(onclick for onclick, _props in _skin_items())
+		self.assertIn('mode=list_display_order_choice&list_type=tmdb', onclicks)
+		self.assertIn('mode=list_display_order_choice&list_type=personal', onclicks)
+
+
+class RouterTests(unittest.TestCase):
+	MODES = ('sort_default_choice', 'list_sort_override_choice')
+
+	def test_both_handler_modes_reach_the_dialogs_branch(self):
+		literals = _router_branch_literals()
+		self.assertEqual('choice', literals[-1])
+		for mode in self.MODES:
+			self.assertIn('choice', mode)
+			for earlier in literals[:-1]:
+				self.assertNotIn(earlier, mode, '%s is swallowed by the %r branch' % (mode, earlier))
+
+	def test_the_dialogs_branch_calls_the_mode_by_name(self):
+		"""router.py execs 'dialogs.%s(params)' % mode, so the mode has to be the function name."""
+		defined = set(i.name for i in ast.walk(_tree(DIALOGS)) if isinstance(i, ast.FunctionDef))
+		for mode in self.MODES:
+			self.assertIn(mode, defined)
+
+
+def _sort_source_calls(path):
+	"""(list_key, media_type, adapter) for every list_sort.sort_source() call in a module.
+	None where the call site passes a variable rather than a literal."""
+	calls = []
+	for node in ast.walk(_tree(path)):
+		if not isinstance(node, ast.Call): continue
+		func = node.func
+		if not isinstance(func, ast.Attribute) or func.attr != 'sort_source': continue
+		literals = [a.value if isinstance(a, ast.Constant) else None for a in node.args]
+		calls.append((literals[1], literals[2], literals[3]))
+	return calls
+
+
+def _sort_cm_calls():
+	"""(list_key, media_type, adapter) for every sort context menu the navigator builds.
+
+	Direct self._sort_cm('trakt.watchlist', 'movies', 'trakt_sync') calls are read straight off.
+	A helper that pins the list key and the adapter and takes only the media type - Simkl's, whose
+	every status list shares one scope - is followed through to its own call sites."""
+	tree = _tree(NAVIGATOR)
+	calls, wrappers = [], {}
+	for node in ast.walk(tree):
+		if not isinstance(node, ast.FunctionDef): continue
+		for child in ast.walk(node):
+			if not isinstance(child, ast.Call): continue
+			if not isinstance(child.func, ast.Attribute) or child.func.attr != '_sort_cm': continue
+			args = [a.value if isinstance(a, ast.Constant) else None for a in child.args]
+			if args[1] is None: wrappers[node.name] = (args[0], args[2])
+			else: calls.append(tuple(args))
+	for node in ast.walk(tree):
+		if not isinstance(node, ast.Call): continue
+		if not isinstance(node.func, ast.Attribute) or node.func.attr not in wrappers: continue
+		list_key, adapter = wrappers[node.func.attr]
+		media_type = node.args[0].value if node.args and isinstance(node.args[0], ast.Constant) else None
+		calls.append((list_key, media_type, adapter))
+	return calls
+
+
+def _media_typed_sort_source_adapters():
+	"""Adapter names of every sort_source() call site that can pass a media type.
+
+	The third argument is unparsed rather than read as a literal: the literal None marks a mixed list,
+	which resolve() can never hand the mediatype default to, while a variable can normalize to
+	movies/shows and therefore can. Those are exactly the adapters the global default governs."""
+	adapters = set()
+	for path in (TRAKT_API, SIMKL_API, MDBLIST_API, PERSONAL_LISTS, TMDB_LISTS):
+		for node in ast.walk(_tree(path)):
+			if not isinstance(node, ast.Call): continue
+			func = node.func
+			if not isinstance(func, ast.Attribute) or func.attr != 'sort_source': continue
+			if len(node.args) < 4: continue
+			if ast.unparse(node.args[2]) == 'None': continue
+			adapters.add(ast.literal_eval(node.args[3]))
+	return adapters
+
+
+class DefaultGovernedAdapterTests(unittest.TestCase):
+	def test_the_governed_adapter_list_matches_the_call_sites(self):
+		"""DEFAULT_GOVERNED_ADAPTERS is a hand-maintained mirror of which call sites pass a media type.
+		Drift either way is silent: too wide and the picker offers a field some list cannot sort by,
+		too narrow and a field that would have worked everywhere is withheld."""
+		self.assertEqual(_media_typed_sort_source_adapters(), set(list_sort.DEFAULT_GOVERNED_ADAPTERS))
+		self.assertEqual(len(list_sort.DEFAULT_GOVERNED_ADAPTERS), len(set(list_sort.DEFAULT_GOVERNED_ADAPTERS)))
+
+	def test_the_mixed_list_adapters_are_excluded(self):
+		for name in ('trakt_list', 'tmdb', 'personal'):
+			self.assertNotIn(name, list_sort.DEFAULT_GOVERNED_ADAPTERS)
+
+	def test_default_field_choices_is_the_intersection(self):
+		expected = set(list_sort.field_choices(list_sort.DEFAULT_GOVERNED_ADAPTERS[0]))
+		for name in list_sort.DEFAULT_GOVERNED_ADAPTERS[1:]:
+			expected &= set(list_sort.field_choices(name))
+		self.assertEqual(expected, set(list_sort.default_field_choices()))
+		self.assertEqual(('title', 'date_added', 'release_date', 'random'), list_sort.default_field_choices())
+
+
+class ContextMenuTests(unittest.TestCase):
+	def test_every_sort_context_menu_matches_a_real_sort_source_call_site(self):
+		"""The context menu writes an override the list builder has to read back. The pair that
+		matters is (list_key, adapter): a mismatch stores a row nothing will ever look up."""
+		known = set((list_key, adapter) for path in (TRAKT_API, SIMKL_API, MDBLIST_API)
+			for list_key, _media_type, adapter in _sort_source_calls(path))
+		calls = _sort_cm_calls()
+		self.assertTrue(calls)
+		for list_key, media_type, adapter in calls:
+			self.assertIn((list_key, adapter), known, '%s/%s has no sort_source call site' % (list_key, adapter))
+			self.assertIn(adapter, list_sort.ADAPTERS)
+			# None where the media type is a loop variable (the flat Simkl menu). Every literal one
+			# has to normalize, or scope_key() drops the suffix and two lists share one override.
+			self.assertIn(media_type, ('movies', 'shows', None))
+
+	def test_the_mediatype_split_lists_all_carry_the_entry(self):
+		pairs = set((list_key, media_type) for list_key, media_type, _adapter in _sort_cm_calls())
+		for list_key in ('trakt.watchlist', 'trakt.collection', 'mdblist.watchlist', 'mdblist.collection', 'simkl'):
+			for media_type in ('movies', 'shows'):
+				self.assertIn((list_key, media_type), pairs)
+
+	def test_the_entry_routes_to_the_override_handler(self):
+		self.assertIn("'mode': 'list_sort_override_choice'", _source(NAVIGATOR))
+
+
+class ContextMenuLabelTests(unittest.TestCase):
+	"""Simkl's five status lists share one scope per media type, so setting the sort from any one of
+	them reorders the other four. The label has to say so; a plain 'Set Custom Sort' reads as
+	list-specific and the reordering looks like a bug."""
+
+	def _sort_cm_def(self):
+		for node in ast.walk(_tree(NAVIGATOR)):
+			if isinstance(node, ast.FunctionDef) and node.name == '_sort_cm': return node
+		self.fail('_sort_cm not found in navigator.py')
+
+	def _label_kwarg(self, wrapper_name):
+		for node in ast.walk(_tree(NAVIGATOR)):
+			if not isinstance(node, ast.FunctionDef) or node.name != wrapper_name: continue
+			for child in ast.walk(node):
+				if not isinstance(child, ast.Call): continue
+				if not isinstance(child.func, ast.Attribute) or child.func.attr != '_sort_cm': continue
+				for kw in child.keywords:
+					if kw.arg == 'label': return ast.unparse(kw.value)
+		return None
+
+	def test_the_default_label_is_the_plain_one(self):
+		defaults = self._sort_cm_def().args
+		names = [a.arg for a in defaults.args]
+		self.assertIn('label', names, '_sort_cm takes no label, so a shared scope cannot say so')
+		offset = len(names) - len(defaults.defaults)
+		default = defaults.defaults[names.index('label') - offset]
+		self.assertEqual('Set Custom Sort', ast.literal_eval(default))
+
+	def test_the_label_reaches_the_menu_entry(self):
+		"""Guards the guard: a label parameter nothing interpolates would pass every other test here."""
+		body = ast.unparse(self._sort_cm_def())
+		self.assertIn('label', body.split('return', 1)[1])
+
+	def test_simkl_says_the_entry_covers_every_simkl_list_of_that_media_type(self):
+		label = self._label_kwarg('_simkl_sort_cm')
+		self.assertIsNotNone(label, 'Simkl uses the plain label, so it claims to sort one list')
+		self.assertIn('All Simkl', label)
+
+	def test_the_per_list_scopes_keep_the_plain_label(self):
+		"""Only a scope backing several visible lists should widen its label."""
+		for node in ast.walk(_tree(NAVIGATOR)):
+			if not isinstance(node, ast.Call): continue
+			if not isinstance(node.func, ast.Attribute) or node.func.attr != '_sort_cm': continue
+			if not node.args or not isinstance(node.args[0], ast.Constant): continue
+			if node.args[0].value == 'simkl': continue
+			self.assertEqual([], [kw for kw in node.keywords if kw.arg == 'label'],
+				'%s backs one visible list, so it should not widen its label' % node.args[0].value)
+
+
+class CallSiteRewiringTests(unittest.TestCase):
+	"""The three UIs that used to write stores nothing reads."""
+
+	def test_the_trakt_list_context_menu_delegates_to_the_override_dialog(self):
+		node = _function(TRAKT_LISTS, 'set_list_custom_sort')
+		self.assertIn('list_sort_override_choice', _called_names(node))
+		scopes = _string_constants(node, 'trakt.list:')
+		self.assertEqual({'trakt.list:%s'}, scopes)
+		self.assertIn('trakt.list:%s', _string_constants(_tree(TRAKT_API), 'trakt.list:'))
+		# The adapter has to be 'trakt_list' (mixed, rank/rating/etc.), not 'trakt_sync' (the
+		# watchlist/collection adapter with none of those fields) - a swap would silently drop every
+		# field a Trakt user list's own picker offers.
+		payload = _call_dict_literal(node, 'list_sort_override_choice')
+		self.assertEqual('trakt_list', payload['adapter'])
+
+	def test_no_trakt_ui_writes_the_legacy_per_list_sort_store_any_more(self):
+		source = _source(TRAKT_LISTS)
+		for legacy in ('set_list_custom_sort(list_id', 'delete_list_custom_sort', 'get_list_custom_sort('):
+			self.assertNotIn(legacy, source)
+
+	def test_the_trakt_artwork_builder_no_longer_reads_the_legacy_store(self):
+		node = _function(TRAKT_LISTS, 'trakt_image_maker')
+		self.assertNotIn('get_list_custom_sort', _called_names(node))
+		self.assertIn('get_trakt_list_contents', _called_names(node))
+
+	def test_the_tmdb_properties_dialog_writes_the_override_store(self):
+		node = _function(TMDB_LISTS, 'adjust_tmdb_list_properties')
+		called = _called_names(node)
+		self.assertIn('set_override', called)
+		self.assertIn('_pick_sort_spec', called)
+		self.assertIn('resolve', called)
+		self.assertEqual({'tmdb:%s'}, _string_constants(node, 'tmdb:'))
+		get_tmdb_list_node = _function(TMDB_LISTS, 'get_tmdb_list')
+		self.assertIn('tmdb:%s', _string_constants(get_tmdb_list_node, 'tmdb:'))
+		# The picker must be handed the tmdb adapter, not some other list's - a swap would silently
+		# offer the wrong field set and let the wrong adapter's fields drive this list's sort.
+		pick_args, _pick_kwargs = _call_args(node, '_pick_sort_spec')
+		self.assertEqual('tmdb', pick_args[1])
+		# The 'Currently ...' label's fallback and get_tmdb_list's own fallback have to be the same
+		# literal - the comment above the resolve() call says so, but nothing besides this enforced
+		# it: a drift here means the label can say something get_tmdb_list would never produce.
+		resolve_args, _resolve_kwargs = _call_args(node, 'resolve')
+		label_fallback = resolve_args[2]
+		_list_args, list_kwargs = _call_args(get_tmdb_list_node, 'sort_source')
+		self.assertEqual('default:asc', label_fallback)
+		self.assertEqual(label_fallback, list_kwargs.get('fallback'))
+
+	def test_no_tmdb_ui_writes_the_legacy_sort_order_column(self):
+		self.assertNotIn('set_sort_order', _source(TMDB_LISTS))
+
+	def test_creating_a_personal_list_stores_the_chosen_sort_as_an_override(self):
+		"""The whole point: the creation prompt used to write only the legacy column, so every list
+		made after the upgrade came back title sorted no matter what the user picked."""
+		node = _function(PERSONAL_LISTS, 'make_new_personal_list')
+		called = _called_names(node)
+		self.assertIn('personal_sort_order', called)
+		self.assertIn('_set_sort_override', called)
+		self.assertIn('make_list', called)
+
+	def test_importing_a_list_stores_its_import_order_as_an_override(self):
+		node = _function(PERSONAL_LISTS, 'run')
+		self.assertIn('make_list', _called_names(node))
+		self.assertIn('_set_sort_override', _called_names(node))
+		# The imported file's own order is date_added ascending. A flip to descending would silently
+		# reverse every list ExternalImport ever creates.
+		spec = _call_dict_literal(node, '_set_sort_override', index=2)
+		self.assertEqual({'field': 'date_added', 'direction': 'asc'}, spec)
+
+	def test_the_personal_properties_dialog_writes_the_override_store(self):
+		node = _function(PERSONAL_LISTS, 'adjust_personal_list_properties')
+		called = _called_names(node)
+		self.assertIn('_set_sort_override', called)
+		self.assertIn('_current_sort_spec', called)
+		self.assertIn('spec_label', called)
+
+	def test_renaming_a_personal_list_carries_its_override_across(self):
+		"""The scope key embeds the name and the author, so a rename orphans the row otherwise."""
+		for name in ('adjust_personal_list_properties', 'import_trakt_list'):
+			self.assertIn('_move_sort_override', _called_names(_function(PERSONAL_LISTS, name)))
+
+	def test_every_personal_scope_literal_is_the_one_get_personal_list_resolves(self):
+		self.assertEqual({'personal:%s|%s'}, _string_constants(_tree(PERSONAL_LISTS), 'personal:'))
+
+	def test_current_sort_spec_passes_no_fallback(self):
+		"""A 'default:asc' fallback here is the exact defect acceptance criterion 1 was about: every
+		list without an override would show 'Provider Default' in the 'Currently ...' label instead
+		of the title sort get_personal_list() actually falls back to. Covered behaviourally too, in
+		tests/test_personal_lists_sort_overrides.py."""
+		node = _function(PERSONAL_LISTS, '_current_sort_spec')
+		positional, keywords = _call_args(node, 'resolve')
+		self.assertEqual(1, len(positional))
+		self.assertNotIn('fallback', keywords)
+
+
+if __name__ == '__main__':
+	unittest.main()

--- a/tests/test_trakt_list_contents_cache_shape.py
+++ b/tests/test_trakt_list_contents_cache_shape.py
@@ -1,0 +1,349 @@
+"""get_trakt_list_contents' cache row has one shape, whoever asks for it.
+
+The disk cache key is built from list_type/user/slug/list_id only - it does not encode the `method`
+the fetch was made with. get_trakt() returns a bare list for method=None and a
+{'sort_by','sort_how','data'} dict for method='sort_by_headers', so two callers asking for the same
+list with different methods write and read incompatible rows under one key. That is what happened
+when the list builder still carried sort_by/sort_how in its folder URL while trakt_image_maker,
+which has no URL to carry them in, called with the default: the builder's row was a dict, the
+custom-sort branch skipped the unwrapping, and the enumerate() below iterated the dict's three keys
+and did i['type'] on a string. Swallowed by the enclosing try - the list simply rendered empty.
+
+The function is compiled straight out of apis/trakt_api.py against stub globals rather than
+imported: the module pulls in the whole Kodi runtime, but this one function only touches
+trakt_cache, get_trakt, list_sort and settings.
+"""
+import ast
+import sys
+import unittest
+
+from test_trakt_sync_list_sort import ROOT, list_sort, _install_stubs, OVERRIDES, SETTINGS
+
+_STUBBED_MODULES = ('caches', 'caches.list_sort_cache', 'caches.settings_cache', 'modules', 'modules.settings')
+
+TRAKT_API = ROOT / 'plugin.video.redlight' / 'resources' / 'lib' / 'apis' / 'trakt_api.py'
+TRAKT_LISTS = ROOT / 'plugin.video.redlight' / 'resources' / 'lib' / 'indexers' / 'trakt_lists.py'
+
+# Ranks are deliberately out of payload order, so "sorted by rank" and "handed back untouched" are
+# different sequences and a fallback that quietly stopped working would be visible here.
+ROWS = [
+	{'type': 'movie', 'rank': 2, 'movie': {'ids': {'trakt': 2}, 'title': 'Banana', 'released': '2001-01-01'}},
+	{'type': 'movie', 'rank': 3, 'movie': {'ids': {'trakt': 3}, 'title': 'Alpha', 'released': '1999-01-01'}},
+	{'type': 'movie', 'rank': 1, 'movie': {'ids': {'trakt': 1}, 'title': 'Cherry', 'released': '2010-01-01'}},
+]
+
+PAYLOAD_ORDER = ['Banana', 'Alpha', 'Cherry']
+RANK_ASC = ['Cherry', 'Banana', 'Alpha']
+
+
+def _tree(path):
+	with open(str(path), 'r', encoding='utf-8') as f:
+		return ast.parse(f.read())
+
+
+def _function(path, name):
+	found = [n for n in ast.walk(_tree(path)) if isinstance(n, ast.FunctionDef) and n.name == name]
+	if len(found) != 1: raise AssertionError('expected exactly one def %s in %s' % (name, path.name))
+	return found[0]
+
+
+class _Harness:
+	"""get_trakt_list_contents compiled against stubs, plus the cache params it asked for."""
+
+	def __init__(self, cache_row):
+		self.cache_row = cache_row
+		self.requested = []
+		node = _function(TRAKT_API, 'get_trakt_list_contents')
+		module = ast.fix_missing_locations(ast.Module(body=[node], type_ignores=[]))
+
+		class _TraktCache:
+			@staticmethod
+			def cache_trakt_object(function, string, params):
+				self.requested.append({'string': string, 'params': params})
+				return self.cache_row
+
+		class _Settings:
+			@staticmethod
+			def ignore_articles(): return False
+
+		namespace = {'trakt_cache': _TraktCache, 'get_trakt': lambda *a, **k: None,
+			'list_sort': list_sort, 'settings': _Settings}
+		exec(compile(module, '<get_trakt_list_contents>', 'exec'), namespace)
+		self.call = namespace['get_trakt_list_contents']
+
+	def titles(self, *args, **kwargs):
+		return [i['title'] for i in self.call(*args, **kwargs)]
+
+	@property
+	def method(self):
+		return self.requested[-1]['params']['method']
+
+
+def _dict_row(sort_by='rank', sort_how='asc'):
+	return {'sort_by': sort_by, 'sort_how': sort_how, 'data': [dict(i) for i in ROWS]}
+
+
+class CacheShapeTests(unittest.TestCase):
+	# Several modules in this suite install their own 'caches'/'modules' stubs at import time, and
+	# sort_source() re-reads sys.modules on every call, so collection order would otherwise decide
+	# whose override store these tests see. Same idiom as tests/test_mixed_list_sort.py.
+	def setUp(self):
+		self._original_sys_modules = dict((k, sys.modules[k]) for k in _STUBBED_MODULES if k in sys.modules)
+		_install_stubs()
+		OVERRIDES.clear()
+		SETTINGS.clear()
+
+	def tearDown(self):
+		for key in _STUBBED_MODULES:
+			if key in self._original_sys_modules: sys.modules[key] = self._original_sys_modules[key]
+			else: sys.modules.pop(key, None)
+		OVERRIDES.clear()
+		SETTINGS.clear()
+
+	def test_every_caller_requests_the_same_method(self):
+		"""The builder, the artwork maker and the random builders all share one cache key, so they
+		must all write the same shape into it."""
+		harness = _Harness(_dict_row())
+		harness.call('my_lists', 'jo', 'faves', True, '42')                # the list builder
+		builder_method = harness.method
+		harness.call('my_lists', 'jo', 'faves', True, '42')                # trakt_image_maker
+		self.assertEqual(builder_method, harness.method)
+		harness.call('my_lists', 'jo', 'faves', True, '42', skip_sort=True)  # the random builders
+		self.assertEqual(builder_method, harness.method)
+		self.assertEqual('sort_by_headers', builder_method)
+
+	def test_all_three_callers_share_one_cache_key(self):
+		# If they ever stop sharing it, the shape agreement above stops mattering - and so does this
+		# whole file. Pinned so that change is a deliberate one.
+		harness = _Harness(_dict_row())
+		harness.call('my_lists', 'jo', 'faves', True, '42')
+		harness.call('my_lists', 'jo', 'faves', True, '42', skip_sort=True)
+		self.assertEqual(1, len(set(i['string'] for i in harness.requested)))
+
+	def test_a_dict_row_is_unwrapped_for_the_skip_caller_too(self):
+		"""'skip' used to bypass the unwrapping entirely: the dict reached enumerate(), i['type'] ran
+		against the string 'sort_by', and every row was swallowed by the try - an empty list."""
+		harness = _Harness(_dict_row())
+		self.assertEqual(PAYLOAD_ORDER, harness.titles('my_lists', 'jo', 'faves', True, '42', skip_sort=True))
+
+	def test_the_skip_flag_does_not_change_the_requested_method(self):
+		"""The one remaining caller-visible knob must not be able to change the cache row's shape."""
+		harness = _Harness(_dict_row())
+		harness.call('my_lists', 'jo', 'faves', True, '42', skip_sort=False)
+		unsorted_method = harness.method
+		harness.call('my_lists', 'jo', 'faves', True, '42', skip_sort=True)
+		self.assertEqual(unsorted_method, harness.method)
+		self.assertEqual('sort_by_headers', unsorted_method)
+
+	def test_the_skip_flag_only_skips_the_sort(self):
+		"""skip_sort must still hand back every row, in payload order - not an empty list, and not a
+		re-ordered one."""
+		harness = _Harness(_dict_row('rank', 'asc'))
+		self.assertEqual(PAYLOAD_ORDER, harness.titles('my_lists', 'jo', 'faves', True, '42', skip_sort=True))
+		self.assertEqual(RANK_ASC, harness.titles('my_lists', 'jo', 'faves', True, '42'))
+
+	def test_a_legacy_bare_list_row_still_reads(self):
+		"""Rows written by the previous build are plain lists. They must survive the upgrade."""
+		harness = _Harness([dict(i) for i in ROWS])
+		self.assertEqual(PAYLOAD_ORDER, harness.titles('my_lists', 'jo', 'faves', True, '42'))
+
+	def test_the_payload_headers_drive_the_fallback_ordering(self):
+		"""Nothing carries sort_by/sort_how in from a URL any more, so the headers in the cached row
+		are the only remaining record of the order Trakt declares for the list."""
+		harness = _Harness(_dict_row('rank', 'asc'))
+		self.assertEqual(RANK_ASC, harness.titles('my_lists', 'jo', 'faves', True, '42'))
+
+	def test_the_builder_and_the_artwork_maker_produce_the_same_order(self):
+		"""trakt_image_maker builds the poster from the first four items the user sees on screen."""
+		harness = _Harness(_dict_row('rank', 'asc'))
+		builder = harness.titles('my_lists', 'jo', 'faves', True, '42')
+		artwork = harness.titles('my_lists', 'jo', 'faves', True, '42')
+		self.assertEqual(builder, artwork)
+		self.assertEqual(RANK_ASC, artwork)
+
+	def test_one_malformed_row_does_not_abort_the_whole_list(self):
+		"""The retitling loop used to dereference i['show'] unguarded, outside any try. A season row
+		with no 'show' - which the extraction loop below it already tolerates by dropping the row -
+		raised KeyError there instead and took every other item on the list down with it."""
+		rows = [dict(ROWS[0]),
+			{'type': 'season', 'rank': 4, 'season': {'number': 1, 'title': 'Season 1'}},  # no 'show'
+			dict(ROWS[1]), dict(ROWS[2])]
+		harness = _Harness({'sort_by': 'rank', 'sort_how': 'asc', 'data': rows})
+		self.assertEqual(RANK_ASC, harness.titles('my_lists', 'jo', 'faves', True, '42'))
+
+	def test_a_malformed_row_does_not_abort_the_skip_sort_path_either(self):
+		rows = [dict(ROWS[0]),
+			{'type': 'episode', 'rank': 4, 'episode': {'season': 1, 'number': 1, 'title': 'Pilot'}},  # no 'show'
+			dict(ROWS[1]), dict(ROWS[2])]
+		harness = _Harness({'sort_by': 'rank', 'sort_how': 'asc', 'data': rows})
+		self.assertEqual(PAYLOAD_ORDER, harness.titles('my_lists', 'jo', 'faves', True, '42', skip_sort=True))
+
+	def test_a_well_formed_season_row_is_still_retitled(self):
+		"""Wrapping the loop in a try must not stop it doing its job."""
+		row = {'type': 'season', 'rank': 4, 'show': {'ids': {'tmdb': 9}, 'title': 'Delta'},
+			'season': {'number': 1, 'title': 'Season 1'}}
+		harness = _Harness({'sort_by': 'rank', 'sort_how': 'asc', 'data': [row]})
+		harness.call('my_lists', 'jo', 'faves', True, '42')
+		self.assertEqual('Delta - Season 1', row['season']['title'])
+
+	def test_headerless_rows_fall_back_to_the_provider_order(self):
+		harness = _Harness({'sort_by': None, 'sort_how': None, 'data': [dict(i) for i in ROWS]})
+		self.assertEqual(PAYLOAD_ORDER, harness.titles('my_lists', 'jo', 'faves', True, '42'))
+
+
+def _positional_arg_count(node, called_name):
+	counts = []
+	for child in ast.walk(node):
+		if not isinstance(child, ast.Call): continue
+		func = child.func
+		name = func.id if isinstance(func, ast.Name) else (func.attr if isinstance(func, ast.Attribute) else None)
+		if name != called_name: continue
+		counts.append((len(child.args), sorted(k.arg for k in child.keywords if k.arg)))
+	return counts
+
+
+RANDOM_LISTS = ROOT / 'plugin.video.redlight' / 'resources' / 'lib' / 'indexers' / 'random_lists.py'
+
+
+def _sort_argument_offences(source, label):
+	"""(offences, call_count) for every get_trakt_list_contents call in `source`.
+
+	Only the sort arguments are forbidden. Other keywords - list_id in particular - are ordinary
+	parameters and say nothing about how the contents get sorted, so they are allowed through. A
+	sixth positional argument is a different matter: it lands past skip_sort, which means the
+	signature grew a slot, and historically that slot was sort_by.
+	"""
+	offences, seen = [], 0
+	for node in ast.walk(ast.parse(source)):
+		if not isinstance(node, ast.Call): continue
+		func = node.func
+		name = func.id if isinstance(func, ast.Name) else (func.attr if isinstance(func, ast.Attribute) else None)
+		if name != 'get_trakt_list_contents': continue
+		seen += 1
+		unparsed = '%s: %s' % (label, ast.unparse(node))
+		if len(node.args) > 5: offences.append('sixth positional argument - %s' % unparsed)
+		for kw in node.keywords:
+			if kw.arg in ('sort_by', 'sort_how'): offences.append('%s= keyword - %s' % (kw.arg, unparsed))
+	return offences, seen
+
+
+class SignatureTests(unittest.TestCase):
+	"""The divergence has to be unexpressible, not merely unexercised.
+
+	While the signature carried sort_by/sort_how, `method` could be made to depend on them again -
+	the exact cache-shape divergence this file exists to prevent - and no caller passed anything that
+	would reveal it. Collapsing them into one boolean removes the vocabulary for saying it.
+	"""
+
+	def test_the_signature_offers_no_sort_at_all(self):
+		node = _function(TRAKT_API, 'get_trakt_list_contents')
+		names = [a.arg for a in node.args.args]
+		self.assertEqual(['list_type', 'user', 'slug', 'with_auth', 'list_id', 'skip_sort'], names)
+		self.assertEqual([], list(node.args.kwonlyargs))
+		self.assertIsNone(node.args.vararg)
+		self.assertIsNone(node.args.kwarg)
+
+	def test_no_sort_name_is_bound_before_the_method_is_chosen(self):
+		"""`method = ... if sort_by ... else ...` must not even be a writable line: at the point the
+		method is chosen, no sort name exists in the function's scope yet."""
+		node = _function(TRAKT_API, 'get_trakt_list_contents')
+		method_line = min(t.lineno for s in ast.walk(node) if isinstance(s, ast.Assign)
+			for t in s.targets if isinstance(t, ast.Name) and t.id == 'method')
+		bound_earlier = [t.id for s in ast.walk(node) if isinstance(s, ast.Assign) and s.lineno <= method_line
+			for t in ast.walk(s) if isinstance(t, ast.Name) and isinstance(t.ctx, ast.Store)]
+		self.assertNotIn('sort_by', bound_earlier)
+		self.assertNotIn('sort_how', bound_earlier)
+		for arg in node.args.args:
+			self.assertNotIn(arg.arg, ('sort_by', 'sort_how', 'sort', 'method', 'mode'))
+		# ...and the flag that does exist is a boolean, so it cannot carry a field name either.
+		self.assertIs(False, node.args.defaults[-1].value)
+
+	def test_the_only_flag_a_caller_can_pass_is_the_skip_flag(self):
+		"""random_lists is the only module that passes a sixth argument, and it passes the boolean."""
+		for node in ast.walk(_tree(RANDOM_LISTS)):
+			if not isinstance(node, ast.Call): continue
+			func = node.func
+			name = func.id if isinstance(func, ast.Name) else (func.attr if isinstance(func, ast.Attribute) else None)
+			if name != 'get_trakt_list_contents': continue
+			self.assertEqual(5, len(node.args), ast.unparse(node))
+			self.assertEqual(['skip_sort'], [k.arg for k in node.keywords], ast.unparse(node))
+			self.assertIs(True, node.keywords[0].value.value, ast.unparse(node))
+
+	def test_no_module_passes_a_sort_string_to_the_contents_reader(self):
+		lib = ROOT / 'plugin.video.redlight' / 'resources' / 'lib'
+		offences, seen = [], 0
+		for path in lib.rglob('*.py'):
+			with open(str(path), 'r', encoding='utf-8') as f:
+				source = f.read()
+			if 'get_trakt_list_contents' not in source: continue
+			found, count = _sort_argument_offences(source, path.name)
+			offences += found
+			seen += count
+		self.assertEqual([], offences)
+		self.assertTrue(seen >= 6, 'expected to find every call site, found %d' % seen)
+
+	def test_the_scan_catches_a_sort_argument_but_not_an_ordinary_keyword(self):
+		"""The scan above only proves something while it is capable of failing. Requiring every
+		keyword to be skip_sort was too strict - it would reject a plain list_id= - so pin what it
+		does and does not object to."""
+		allowed = ("get_trakt_list_contents('my_lists', u, s, True, lid)",
+			"get_trakt_list_contents('my_lists', u, s, True, lid, skip_sort=True)",
+			"get_trakt_list_contents('my_lists', u, s, True, list_id=lid)",
+			"get_trakt_list_contents('my_lists', u, s, True, list_id=lid, skip_sort=True)")
+		for source in allowed:
+			self.assertEqual(([], 1), _sort_argument_offences(source, 'x.py'), source)
+		forbidden = ("get_trakt_list_contents('my_lists', u, s, True, lid, 'rank')",
+			"get_trakt_list_contents('my_lists', u, s, True, lid, sort_by='rank')",
+			"get_trakt_list_contents('my_lists', u, s, True, lid, sort_how='asc')",
+			"get_trakt_list_contents('my_lists', u, s, True, list_id=lid, sort_by='rank')")
+		for source in forbidden:
+			found, seen = _sort_argument_offences(source, 'x.py')
+			self.assertEqual(1, seen, source)
+			self.assertEqual(1, len(found), source)
+
+
+class CallSiteTests(unittest.TestCase):
+	def test_no_caller_asks_for_a_client_side_sort(self):
+		"""Five positional arguments: list_type, user, slug, with_auth, list_id. A sixth is a sort_by,
+		which is exactly what split the two callers apart."""
+		for name in ('build_trakt_list', 'trakt_image_maker'):
+			calls = _positional_arg_count(_function(TRAKT_LISTS, name), 'get_trakt_list_contents')
+			self.assertEqual([(5, [])], calls, name)
+
+	def test_the_legacy_per_list_sort_store_is_no_longer_read(self):
+		with open(str(TRAKT_LISTS), 'r', encoding='utf-8') as f:
+			source = f.read()
+		self.assertNotIn('get_all_lists_custom_sort', source)
+		self.assertNotIn('all_custom_sorts', source)
+
+	def test_no_trakt_list_folder_url_carries_a_sort(self):
+		"""A sort_by in the folder URL is what build_trakt_list read back out and passed on. Every
+		url_params dict that names a build_trakt_list-ish mode must be free of both keys."""
+		checked = 0
+		for node in ast.walk(_tree(TRAKT_LISTS)):
+			if not isinstance(node, ast.Dict): continue
+			keys = [k.value for k in node.keys if isinstance(k, ast.Constant)]
+			if 'mode' not in keys: continue
+			source = ast.unparse(node)
+			if 'build_trakt_list' not in source: continue
+			checked += 1
+			self.assertNotIn("'sort_by'", source, source)
+			self.assertNotIn("'sort_how'", source, source)
+		self.assertTrue(checked >= 4, 'expected to find the list folder URL dicts, found %d' % checked)
+
+	def test_the_set_custom_sort_menu_still_carries_trakts_declared_order(self):
+		"""It is not a folder URL: those two values are the fallback the "Use Default" choice resolves
+		to, and they now come from the Trakt list metadata rather than from the legacy store."""
+		checked = 0
+		for node in ast.walk(_tree(TRAKT_LISTS)):
+			if not isinstance(node, ast.Dict): continue
+			if 'set_list_custom_sort' not in ast.unparse(node): continue
+			keys = [k.value for k in node.keys if isinstance(k, ast.Constant)]
+			checked += 1
+			self.assertIn('sort_by', keys)
+			self.assertIn('sort_how', keys)
+		self.assertEqual(2, checked, 'expected both Set Custom Sort context menu entries')
+
+
+if __name__ == '__main__':
+	unittest.main()

--- a/tests/test_trakt_sync_list_sort.py
+++ b/tests/test_trakt_sync_list_sort.py
@@ -1,0 +1,122 @@
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+LIST_SORT_PATH = ROOT / 'plugin.video.redlight' / 'resources' / 'lib' / 'modules' / 'list_sort.py'
+
+OVERRIDES = {}
+SETTINGS = {}
+
+
+def _install_stubs():
+	caches = types.ModuleType('caches')
+	caches.__path__ = []
+	list_sort_cache = types.ModuleType('caches.list_sort_cache')
+	_media = {'movie': 'movies', 'movies': 'movies', 'show': 'shows', 'shows': 'shows', 'tvshow': 'shows'}
+
+	def scope_key(list_key, media_type=None):
+		normalized = _media.get(str(media_type).lower(), '') if media_type else ''
+		return '%s:%s' % (list_key, normalized) if normalized else list_key
+
+	list_sort_cache.scope_key = scope_key
+	list_sort_cache.normalize_media_type = lambda m: _media.get(str(m).lower(), '') if m else ''
+	list_sort_cache.get_override = lambda scope: OVERRIDES.get(scope, '')
+	list_sort_cache.set_override = lambda scope, spec: True
+	settings_cache = types.ModuleType('caches.settings_cache')
+	settings_cache.get_setting = lambda setting_id, fallback='': SETTINGS.get(setting_id, fallback)
+	modules = types.ModuleType('modules')
+	modules.__path__ = []
+	settings = types.ModuleType('modules.settings')
+	settings.ignore_articles = lambda: True
+	sys.modules['caches'] = caches
+	sys.modules['caches.list_sort_cache'] = list_sort_cache
+	sys.modules['caches.settings_cache'] = settings_cache
+	sys.modules['modules'] = modules
+	sys.modules['modules.settings'] = settings
+
+
+def _load_list_sort_module():
+	_install_stubs()
+	spec = importlib.util.spec_from_file_location('list_sort_source_under_test', LIST_SORT_PATH)
+	module = importlib.util.module_from_spec(spec)
+	spec.loader.exec_module(module)
+	return module
+
+
+list_sort = _load_list_sort_module()
+
+# collected_at is deliberately NOT in title order: date_added:desc must produce the reverse of
+# title:asc for this fixture, so a sort_source that ignores media_type and always falls back to
+# DEFAULT_SPEC (title:asc) is caught by test_movies_and_shows_sort_independently instead of
+# accidentally producing the same order either way.
+MOVIES = [
+	{'title': 'Banana', 'collected_at': '2024-01-03', 'released': '2001-01-01'},
+	{'title': 'The Apple', 'collected_at': '2024-01-02', 'released': '1999-01-01'},
+]
+SHOWS = [
+	{'title': 'Zulu', 'collected_at': '2024-01-03', 'released': '2001-01-01'},
+	{'title': 'Alpha', 'collected_at': '2024-01-02', 'released': '1999-01-01'},
+]
+
+
+class SortSourceTests(unittest.TestCase):
+	def setUp(self):
+		# Other test modules in this suite install their own fake 'caches'/'modules' stubs into
+		# sys.modules at import time with no cleanup, and this file is one of them. When the full
+		# suite runs, collection order can clobber our stub before these tests execute, since
+		# sort_source()/resolve() re-read sys.modules lazily on every call. Reinstall ours here so
+		# each test sees the fakes this file installed, regardless of collection order. Mirrors
+		# tests/test_list_sort_resolve.py, which carries the same save/restore pair for the same
+		# reason.
+		self._original_sys_modules = {}
+		for key in ('caches', 'caches.list_sort_cache', 'caches.settings_cache', 'modules', 'modules.settings'):
+			if key in sys.modules:
+				self._original_sys_modules[key] = sys.modules[key]
+		_install_stubs()
+		OVERRIDES.clear()
+		SETTINGS.clear()
+
+	def tearDown(self):
+		for key in ('caches', 'caches.list_sort_cache', 'caches.settings_cache', 'modules', 'modules.settings'):
+			if key in self._original_sys_modules:
+				sys.modules[key] = self._original_sys_modules[key]
+			else:
+				sys.modules.pop(key, None)
+		OVERRIDES.clear()
+		SETTINGS.clear()
+
+	def test_movies_and_shows_sort_independently(self):
+		SETTINGS['redlight.sort.default.movies'] = 'date_added:desc'
+		SETTINGS['redlight.sort.default.shows'] = 'title:asc'
+		movies = list_sort.sort_source(list(MOVIES), 'trakt.watchlist', 'movies', 'trakt_sync')
+		shows = list_sort.sort_source(list(SHOWS), 'trakt.watchlist', 'shows', 'trakt_sync')
+		self.assertEqual(['Banana', 'The Apple'], [i['title'] for i in movies])
+		self.assertEqual(['Alpha', 'Zulu'], [i['title'] for i in shows])
+
+	def test_per_list_override_applies_to_one_media_type_only(self):
+		SETTINGS['redlight.sort.default.movies'] = 'title:asc'
+		OVERRIDES['trakt.collection:movies'] = 'release_date:desc'
+		collection = list_sort.sort_source(list(MOVIES), 'trakt.collection', 'movies', 'trakt_sync')
+		watchlist = list_sort.sort_source(list(MOVIES), 'trakt.watchlist', 'movies', 'trakt_sync')
+		self.assertEqual(['Banana', 'The Apple'], [i['title'] for i in collection])
+		self.assertEqual(['The Apple', 'Banana'], [i['title'] for i in watchlist])
+
+	def test_unknown_adapter_returns_input_unchanged(self):
+		result = list_sort.sort_source(list(MOVIES), 'trakt.watchlist', 'movies', 'nope')
+		self.assertEqual(['Banana', 'The Apple'], [i['title'] for i in result])
+
+	def test_none_data_is_safe(self):
+		self.assertEqual(None, list_sort.sort_source(None, 'trakt.watchlist', 'movies', 'trakt_sync'))
+
+	def test_reads_ignore_articles_setting(self):
+		SETTINGS['redlight.sort.default.movies'] = 'title:asc'
+		result = list_sort.sort_source(list(MOVIES), 'trakt.watchlist', 'movies', 'trakt_sync')
+		self.assertEqual(['The Apple', 'Banana'], [i['title'] for i in result])
+
+
+if __name__ == '__main__':
+	unittest.main()


### PR DESCRIPTION
## What

 Fixes #40 

Lists can now sort Movies and TV Shows independently. Setting the TV watchlist to Title while Movies sorts by Date Added is the case this started from.

Doing that on top of the existing code would have meant a sixth sort mechanism. There were already five, with three different asc/desc encodings, title sort stuck ascending everywhere, and inconsistent article stripping. This replaces all five with one model.

- **One sort spec** — `{field, direction}` — instead of int codes whose meaning varied per provider
- **One engine + per-source adapters.** A new provider means writing an adapter, not another mechanism
- **One store** for per-list overrides (`list_sort` table), replacing three separate legacy stores
- **Two settings** — default sort for Movies, default sort for TV Shows — instead of a row per list per media type

## Behaviour

**Existing users keep their current ordering.** The migration translates all five legacy mechanisms and runs once on upgrade. Where a provider only implemented some of its sort codes, it is migrated through its own table rather than the shared one, so nothing silently changes:

- MDBList only ever honoured codes 0/1/2 — codes 3/4 meant Title there while meaning ascending date elsewhere. Preserved as Title.
- Trakt user lists and TMDb lists with no stored custom sort keep the provider's own ordering rather than falling to Title.

**One deliberate exception: title sorting is now case-insensitive.** `iZombie`, `eXistenZ` and `xXx` sort among the `i`/`e`/`x` titles instead of ahead of every lowercase letter. The old code was case-sensitive in three of its four paths. This is the only place ordering changes on upgrade, and it is documented as intentional in `strip_articles`.

**New controls.** Settings → Content → List Sort Order sets the two defaults. Any list can override from its context menu, with "Use Default" to clear. Simkl's five status lists share one scope per media type, and its menu entry says so.

**Also fixed along the way:** creating a personal list prompted for a sort order that was never read; TMDb and personal "change sort order" controls wrote to stores nothing read; TMDb multi-page lists lost provider order because pages are fetched concurrently.

## Changes

31 files, +4450/−311.

- `modules/list_sort.py` — new. Spec model, engine, seven adapters, migration tables
- `caches/list_sort_cache.py` + `list_sort` table — new. Per-list override store
- `caches/settings_cache.py` — two new settings, five removed, migration wired into `sync_settings`
- `apis/trakt_api.py`, `apis/simkl_api.py`, `apis/mdblist_api.py`, `indexers/personal_lists.py`, `indexers/tmdb_lists.py`, `indexers/trakt_lists.py` — call sites moved to the engine
- `indexers/dialogs.py`, `indexers/navigator.py`, `skins/Default/1080i/settings_manager.xml` — settings rows, pickers, context-menu entries
- `modules/settings.py`, `modules/utils.py` — superseded sorters removed
- `tests/` — 302 tests

**Migration is one-way.** It reads the legacy settings and stores once, then marks itself done. A failed run leaves the sentinel unset and the legacy values intact so the next sync retries rather than closing the door.

**Not covered by tests:** the skin XML and Kodi dialogs have no automated coverage — no Kodi runtime in CI. Need to Verify manually: settings rows render and change, both watchlists sorting differently on screen, TMDb watchlist over one page, custom poster on a Trakt list, personal list creation.

Based on `main` at 2c2422f (v1.9.8), applied as a single commit.

Also brings across `tests/test_settings_cache_calendar_migration.py`. It exists in my fork but not here — the calendar feature was merged without it — and the migration tests in this PR reuse its `sync_settings` harness rather than duplicating one.

One note on the test suite: `test_trakt_calendar_date_labels.py::test_default_setting_metadata` already fails on `main` before this branch — the test still expects the four original date-label options while `settings_cache` now declares nine. I ran it in a clean worktree at 2c2422f to confirm it's pre-existing and left it alone. Everything else is green: 312 passed.
