### PR TITLE
⚡ Use mini icon in progress and notification dialogs

### DIFF
--- a/plugin.video.redlight/resources/lib/modules/kodi_utils.py
+++ b/plugin.video.redlight/resources/lib/modules/kodi_utils.py
@@ -1029,7 +1029,7 @@ def external_scraper_settings(params=None):
 def progress_dialog(heading='', icon=None):
 	from threading import Thread
 	from windows.base_window import create_window
-	progress_dialog = create_window(('windows.progress', 'Progress'), 'progress.xml', heading=heading, icon=icon or addon_icon())
+	progress_dialog = create_window(('windows.progress', 'Progress'), 'progress.xml', heading=heading, icon=icon or addon_icon_mini())
 	Thread(target=progress_dialog.run).start()
 	for _ in range(40):
 		try:
@@ -1103,7 +1103,7 @@ def notification(line1, time=5000, icon=None, settle_ms=0):
 	# Brief delay helps Kodi show the toast after select/confirm dialogs close (rapid calls can drop it otherwise).
 	# sound=False: silent toast — especially during playback (Next Episode Ready, Next Up).
 	if settle_ms: sleep(settle_ms)
-	kodi_dialog().notification('Red Light', line1, icon or addon_icon(), time, False)
+	kodi_dialog().notification('Red Light', line1, icon or addon_icon_mini(), time, False)
 
 def player_check(mode, params):
 	from modules.settings import playback_key


### PR DESCRIPTION
Icon with transparent background looks nicer.

## BEFORE
<img width="1899" height="964" alt="image" src="https://github.com/user-attachments/assets/f444311f-1edf-4351-928f-757cc05a30a8" />

## AFTER
<img width="1870" height="948" alt="image" src="https://github.com/user-attachments/assets/75a7f214-73ed-4aef-a22e-3085dfae5ceb" />