### PR TITLE
⚡ Improve episode label formatting

### DIFF
--- a/plugin.video.redlight/resources/lib/caches/settings_cache.py
+++ b/plugin.video.redlight/resources/lib/caches/settings_cache.py
@@ -1222,8 +1222,8 @@ def default_settings():
 #====================================SINGLE EPISODE LISTS==========================#
 #==================================================================================#
 #==================== General
-{'setting_id': 'single_ep_display', 'setting_type': 'action', 'setting_default': '0', 'settings_options': {'0': 'TITLE: SxE - EPISODE', '1': 'SxE - EPISODE', '2': 'EPISODE'}},
-{'setting_id': 'single_ep_display_widget', 'setting_type': 'action', 'setting_default': '1', 'settings_options': {'0': 'TITLE: SxE - EPISODE', '1': 'SxE - EPISODE', '2': 'EPISODE'}},
+{'setting_id': 'single_ep_display', 'setting_type': 'action', 'setting_default': '0', 'settings_options': {'0': 'TITLE - SxE. EPISODE', '1': 'SxE. EPISODE', '2': 'EPISODE'}},
+{'setting_id': 'single_ep_display_widget', 'setting_type': 'action', 'setting_default': '1', 'settings_options': {'0': 'TITLE - SxE. EPISODE', '1': 'SxE. EPISODE', '2': 'EPISODE'}},
 {'setting_id': 'single_ep_unwatched_episodes', 'setting_type': 'boolean', 'setting_default': 'false'},
 #==================== Next Episodes
 {'setting_id': 'nextep.method', 'setting_type': 'action', 'setting_default': '0', 'settings_options': {'0': 'Last Aired', '1': 'Last Watched'}},
@@ -1237,8 +1237,8 @@ def default_settings():
 {'setting_id': 'nextep.include_unaired', 'setting_type': 'boolean', 'setting_default': 'false'},
 #======+============= Calendars (Trakt + MDBList + PunchPlay — shared episode-list UI)
 {'setting_id': 'trakt.flatten_episodes', 'setting_type': 'boolean', 'setting_default': 'false'},
-{'setting_id': 'trakt.calendar_display', 'setting_type': 'action', 'setting_default': '0', 'settings_options': {'0': 'TITLE: SxE - EPISODE', '1': 'SxE - EPISODE', '2': 'EPISODE'}},
-{'setting_id': 'trakt.calendar_display_widget', 'setting_type': 'action', 'setting_default': '1', 'settings_options': {'0': 'TITLE: SxE - EPISODE', '1': 'SxE - EPISODE', '2': 'EPISODE'}},
+{'setting_id': 'trakt.calendar_display', 'setting_type': 'action', 'setting_default': '0', 'settings_options': {'0': 'TITLE - SxE. EPISODE', '1': 'SxE. EPISODE', '2': 'EPISODE'}},
+{'setting_id': 'trakt.calendar_display_widget', 'setting_type': 'action', 'setting_default': '1', 'settings_options': {'0': 'TITLE - SxE. EPISODE', '1': 'SxE. EPISODE', '2': 'EPISODE'}},
 {'setting_id': 'trakt.calendar_sort_order', 'setting_type': 'action', 'setting_default': '0', 'settings_options': {'0': 'Descending', '1': 'Ascending'}},
 {'setting_id': 'trakt.calendar_date_labels', 'setting_type': 'action', 'setting_default': '0', 'settings_options': {
 	'0': 'Words / YYYY-MM-DD', '7': 'Words / MM-DD-YYYY', '8': 'Words / DD-MM-YYYY',

--- a/plugin.video.redlight/resources/lib/indexers/episodes.py
+++ b/plugin.video.redlight/resources/lib/indexers/episodes.py
@@ -81,10 +81,12 @@ def build_episode_list(params):
 				if not duration:
 					duration = show_duration
 					item['duration'] = duration
+				str_episode_zfill2 = str(episode).zfill(2)
+				seas_ep = '%sx%s. ' % (season, str_episode_zfill2)
 				if not episode_date or current_date < episode_date:
-					display, unaired = '[COLOR red][I]%s[/I][/COLOR]' % ep_name, True
+					display, unaired = '[COLOR red][I]%s%s[/I][/COLOR]' % (seas_ep, ep_name), True
 					item['title'] = display
-				else: display, unaired = ep_name, False
+				else: display, unaired = '%s%s' % (seas_ep, ep_name), False
 				extras_params = build_url({'mode': 'extras_menu_choice', 'tmdb_id': tmdb_id, 'media_type': 'episode', 'is_external': is_external})
 				options_params = build_url({'mode': 'options_menu_choice', 'content': 'episode', 'tmdb_id': tmdb_id, 'poster': show_poster, 'is_external': is_external})
 				playback_options_params = build_url({'mode': 'playback_choice', 'media_type': 'episode', 'meta': tmdb_id, 'season': season, 'playcount': playcount,
@@ -114,7 +116,7 @@ def build_episode_list(params):
 				cm = [i[1] for i in cm]
 				studios = list(studio) if isinstance(studio, tuple) else (studio or [])
 				info_tag = listitem.getVideoInfoTag(True)
-				info_tag.setMediaType('episode'), info_tag.setTitle(display), info_tag.setOriginalTitle(orig_title), info_tag.setTvShowTitle(title), info_tag.setGenres(genre)
+				info_tag.setMediaType('episode'), info_tag.setTitle(ep_name), info_tag.setOriginalTitle(orig_title), info_tag.setTvShowTitle(title), info_tag.setGenres(genre)
 				info_tag.setPlaycount(playcount), info_tag.setSeason(season), info_tag.setEpisode(episode), info_tag.setPlot(plot)
 				info_tag.setDuration(duration), info_tag.setIMDBNumber(imdb_id), info_tag.setUniqueIDs({'imdb': imdb_id, 'tmdb': str(tmdb_id), 'tvdb': str(tvdb_id)})
 				info_tag.setFirstAired(premiered), info_tag.setTvShowStatus(show_status)
@@ -185,7 +187,7 @@ def build_episode_list(params):
 		except: season_poster = show_poster
 		category_name = 'Season %s' % season
 	kodi_utils.add_items(handle, list(_process()))
-	kodi_utils.set_sort_method(handle, 'episodes')
+	kodi_utils.set_sort_method(handle, 'episodes', labelMask='%L')
 	kodi_utils.set_content(handle, 'episodes')
 	kodi_utils.set_category(handle, category_name)
 	kodi_utils.end_directory(handle, cacheToDisc=False if is_external else True)
@@ -261,10 +263,10 @@ def build_single_episode(list_type, params={}):
 				poster_path = next((i['poster_path'] for i in season_data if i['season_number'] == int(season)), None)
 				season_poster = 'https://image.tmdb.org/t/p/w780%s' % poster_path if poster_path is not None else show_poster
 			except: season_poster = show_poster
-			str_season_zfill2, str_episode_zfill2 = str(season).zfill(2), str(episode).zfill(2)
-			if display_format == 0: title_str = '%s: ' % title
+			str_episode_zfill2 = str(episode).zfill(2)
+			if display_format == 0: title_str = '%s - ' % title
 			else: title_str = ''
-			if display_format in (0, 1): seas_ep = '%sx%s - ' % (str_season_zfill2, str_episode_zfill2)
+			if display_format in (0, 1): seas_ep = '%sx%s. ' % (str(season), str_episode_zfill2)
 			else: seas_ep = ''
 			if not list_type_starts_with('next_'):
 				playcount = ws.get_watched_status_episode(watched_info, (season, episode))
@@ -339,7 +341,7 @@ def build_single_episode(list_type, params={}):
 			if isinstance(studio, tuple): studio = list(studio)
 			elif not studio: studio = []
 			info_tag = listitem.getVideoInfoTag(True)
-			info_tag.setMediaType('episode'), info_tag.setOriginalTitle(orig_title), info_tag.setTvShowTitle(title), info_tag.setTitle(display), info_tag.setGenres(genre)
+			info_tag.setMediaType('episode'), info_tag.setOriginalTitle(orig_title), info_tag.setTvShowTitle(title), info_tag.setTitle(ep_name), info_tag.setGenres(genre)
 			info_tag.setPlaycount(playcount), info_tag.setSeason(season), info_tag.setEpisode(episode), info_tag.setPlot(plot), info_tag.setFirstAired(premiered)
 			info_tag.setDuration(duration), info_tag.setIMDBNumber(imdb_id), info_tag.setUniqueIDs({'imdb': imdb_id, 'tmdb': str(tmdb_id), 'tvdb': str(tvdb_id)})
 			info_tag.setCountries(meta_get('country', [])), info_tag.setTrailer(trailer), info_tag.setTvShowStatus(show_status)
@@ -360,7 +362,7 @@ def build_single_episode(list_type, params={}):
 				'episode_type': episode_type, 'redlight.extras_params': extras_params, 'redlight.options_params': options_params,
 				'redlight.playback_options_params': playback_options_params
 				})
-			item_list_append({'list_items': (play_params, listitem, False), 'first_aired': premiered, 'name': '%s - %sx%s' % (title, str_season_zfill2, str_episode_zfill2),
+			item_list_append({'list_items': (play_params, listitem, False), 'first_aired': premiered, 'name': '%s - %sx%s' % (title, str(season), str_episode_zfill2),
 							'unaired': unaired, 'last_played': ep_data_get('last_played', resinsert), 'sort_order': _position, 'unwatched': ep_data_get('unwatched')})
 		except Exception as e:
 			# Silent drops blank calendars/next-ep lists; log so meta/InfoTag failures are visible.
@@ -521,6 +523,6 @@ def build_single_episode(list_type, params={}):
 	kodi_utils.set_category(handle, _get_category_name())
 	# Keep plugin order for calendars — Kodi "Sort by Date" was reordering vs day labels.
 	if list_type_compare in ('trakt_calendar', 'mdblist_calendar', 'punchplay_calendar', 'trakt_recently_aired'):
-		kodi_utils.set_sort_method(handle, 'none')
+		kodi_utils.set_sort_method(handle, 'none', labelMask='%L')
 	kodi_utils.end_directory(handle, cacheToDisc=False)
 	kodi_utils.set_view_mode('view.episodes_single', 'episodes', is_external, fallback_view_types=('view.episodes',))

--- a/plugin.video.redlight/resources/lib/modules/kodi_utils.py
+++ b/plugin.video.redlight/resources/lib/modules/kodi_utils.py
@@ -570,8 +570,8 @@ def service_scrobbler_defer(addon_id, auth_keys=(), scrobble_enable_keys=()):
 def container_content():
 	return get_infolabel('Container.Content')
 
-def set_sort_method(handle, method):
-	xbmcplugin.addSortMethod(handle, {'episodes': 24, 'files': 5, 'label': 2, 'none': 0}[method])
+def set_sort_method(handle, method, labelMask=''):
+	xbmcplugin.addSortMethod(handle, {'episodes': 24, 'files': 5, 'label': 2, 'none': 0}[method], labelMask=labelMask)
 
 def make_session(url='https://'):
 	import requests


### PR DESCRIPTION
- Allows greater skinning flexibility by separating Title and Label values.
- Matches Kodi's core SxE formatting.

1. ListItem.Title returns unformatted infotag "Title" value of the item (without the SxE prefix).
2. ListItem.Label returns formatted values with SxE prefix (unaired red + italics stylization, honors single_episode_list display format setting, etc.).
3. COLOR and ITALICS formatting now encompasses the SxE prefix inside a season folder (build_episode_list)

Note: This PR doesn't offer any additional functionality/new features, just some aesthetic improvements.

## BEFORE
### "Combined view" offered by several skins. Basically two containers: Primary season container and a secondary container below that uses `$INFO[ListItem.FolderPath]` to display the episodes of the focused season.
<img width="3840" height="1206" alt="image" src="https://github.com/user-attachments/assets/3fdf8838-2be0-4d48-a873-23e3fdd2aca5" />

## AFTER
<img width="3840" height="1202" alt="image" src="https://github.com/user-attachments/assets/6205aa57-b05e-476e-9371-ff12d22b2371" />

## BEFORE
### Inside the Season folder (notice the SxE prefixes)
<img width="3840" height="1175" alt="image" src="https://github.com/user-attachments/assets/0535c483-723f-404a-b2b7-450abd5bd836" />
<img width="3840" height="1015" alt="image" src="https://github.com/user-attachments/assets/a8dee4d5-3d5e-4851-8e2e-e676530ec3b8" />


## AFTER
<img width="3840" height="1178" alt="image" src="https://github.com/user-attachments/assets/cc8b4f6d-3924-4ff2-9fd6-bf973b2b4547" />
<img width="3840" height="1102" alt="image" src="https://github.com/user-attachments/assets/fd0da8ed-f40c-4d6a-88aa-d309dcbda537" />